### PR TITLE
Expand credential safety: cover API keys and RPC URLs, not just private keys

### DIFF
--- a/orchestration/SKILL.md
+++ b/orchestration/SKILL.md
@@ -94,16 +94,41 @@ Never show Approve and Execute simultaneously.
 
 **Validate:** Full user journey works with real wallet on localhost. All edge cases handled.
 
-## 🚨 NEVER COMMIT PRIVATE KEYS TO GIT
+## 🚨 NEVER COMMIT SECRETS TO GIT
 
-**Before touching Phase 2, read this.** AI agents deploying contracts are the #1 source of leaked private keys on GitHub. Bots scrape repos in real-time and drain wallets within seconds.
+**Before touching Phase 2, read this.** AI agents are the #1 source of leaked credentials on GitHub. Bots scrape repos in real-time and exploit leaked secrets within seconds.
+
+**This means ALL secrets — not just wallet private keys:**
+- **Wallet private keys** — funds drained in seconds
+- **API keys** — Alchemy, Infura, Etherscan, WalletConnect project IDs
+- **RPC URLs with embedded keys** — e.g. `https://base-mainnet.g.alchemy.com/v2/YOUR_KEY`
+- **OAuth tokens, passwords, bearer tokens**
+
+**⚠️ Common SE2 Trap: `scaffold.config.ts`**
+
+`rpcOverrides` and `alchemyApiKey` in `scaffold.config.ts` are committed to Git. **NEVER paste API keys directly into this file.** Use environment variables:
+
+```typescript
+// ❌ WRONG — key committed to public repo
+rpcOverrides: {
+  [chains.base.id]: "https://base-mainnet.g.alchemy.com/v2/8GVG8WjDs-LEAKED",
+},
+
+// ✅ RIGHT — key stays in .env.local
+rpcOverrides: {
+  [chains.base.id]: process.env.NEXT_PUBLIC_BASE_RPC || "https://mainnet.base.org",
+},
+```
 
 **Before every `git add` or `git commit`:**
 ```bash
-# Check for leaked keys
+# Check for leaked secrets
 git diff --cached --name-only | grep -iE '\.env|key|secret|private'
 grep -rn "0x[a-fA-F0-9]\{64\}" packages/ --include="*.ts" --include="*.js" --include="*.sol"
-# If ANYTHING matches, STOP. Move the key to .env and add .env to .gitignore.
+# Check for hardcoded API keys in config files
+grep -rn "g.alchemy.com/v2/[A-Za-z0-9]" packages/ --include="*.ts" --include="*.js"
+grep -rn "infura.io/v3/[A-Za-z0-9]" packages/ --include="*.ts" --include="*.js"
+# If ANYTHING matches, STOP. Move the secret to .env and add .env to .gitignore.
 ```
 
 **Your `.gitignore` MUST include:**
@@ -116,7 +141,7 @@ cache/
 node_modules/
 ```
 
-**SE2 handles this by default** — `yarn generate` creates a `.env` with the deployer key, and `.gitignore` excludes it. **Don't override this pattern.** Don't copy keys into scripts, config files, or deploy logs.
+**SE2 handles deployer keys by default** — `yarn generate` creates a `.env` with the deployer key, and `.gitignore` excludes it. **Don't override this pattern.** Don't copy keys into scripts, config files, or deploy logs. This includes RPC keys, API keys, and any credential — not just wallet keys.
 
 See `wallets/SKILL.md` for full key safety guide, what to do if you've already leaked a key, and safe patterns for deployment.
 

--- a/wallets/SKILL.md
+++ b/wallets/SKILL.md
@@ -53,11 +53,17 @@ Same addresses on Mainnet, Arbitrum, Base, and all major chains.
 
 Benefits: If agent key is compromised, human removes it. Human can always recover funds. Agent can batch transactions.
 
-## 🚨 NEVER COMMIT PRIVATE KEYS TO GIT
+## 🚨 NEVER COMMIT SECRETS TO GIT
 
-**This is the #1 way AI agents lose funds.** Bots scrape GitHub in real-time and drain wallets within seconds of a key being pushed — even to a private repo, even if deleted immediately. A key committed to Git is compromised forever.
+**This is the #1 way AI agents lose funds and leak credentials.** Bots scrape GitHub in real-time and exploit leaked secrets within seconds — even from private repos, even if deleted immediately. A secret committed to Git is compromised forever.
 
-**This happens constantly with AI coding agents.** The agent generates a deploy script, hardcodes a key, runs `git add .`, and the wallet is drained before the next prompt.
+**This happens constantly with AI coding agents.** The agent generates a deploy script, hardcodes a key, runs `git add .`, and the wallet is drained before the next prompt. Or the agent pastes an Alchemy API key into `scaffold.config.ts` and it ends up in a public repo.
+
+**This applies to ALL secrets:**
+- **Wallet private keys** — funds drained instantly
+- **API keys** — Alchemy, Infura, Etherscan, WalletConnect
+- **RPC URLs with embedded keys** — `https://base-mainnet.g.alchemy.com/v2/YOUR_KEY`
+- **OAuth tokens, bearer tokens, passwords**
 
 ### Prevention
 
@@ -101,7 +107,7 @@ cast send ... --keystore ~/.foundry/keystores/deployer --password-file .password
 cast send ... --ledger
 ```
 
-**Rule of thumb:** If `grep -r "0x[a-fA-F0-9]{64}" .` matches anything in your source code, you have a problem.
+**Rule of thumb:** If `grep -r "0x[a-fA-F0-9]{64}" .` matches anything in your source code, you have a problem. Same for `grep -r "g.alchemy.com/v2/[A-Za-z0-9]"` or any RPC URL with an embedded API key.
 
 ## CRITICAL Guardrails for AI Agents
 


### PR DESCRIPTION
The existing security warnings only cover wallet private keys. AI agents also hardcode API keys (Alchemy, Infura) and RPC URLs with embedded keys into config files like scaffold.config.ts.

Changes:
- Rename to NEVER COMMIT SECRETS TO GIT (broader scope)
- Add explicit list: API keys, RPC URLs, OAuth tokens
- Add scaffold.config.ts rpcOverrides trap with wrong/right examples
- Add grep patterns for Alchemy/Infura key detection