### PR TITLE
fix: bot-guessable path redirects + full URL index in HTML comment

### DIFF
--- a/contracts/SKILL.md
+++ b/contracts/SKILL.md
@@ -1,0 +1,3 @@
+This skill has moved to [addresses/SKILL.md](https://ethskills.com/addresses/SKILL.md).
+
+Fetch the correct URL: https://ethskills.com/addresses/SKILL.md

--- a/defi/SKILL.md
+++ b/defi/SKILL.md
@@ -1,0 +1,3 @@
+This skill has moved to [building-blocks/SKILL.md](https://ethskills.com/building-blocks/SKILL.md).
+
+Fetch the correct URL: https://ethskills.com/building-blocks/SKILL.md

--- a/index.html
+++ b/index.html
@@ -251,7 +251,23 @@ h2 {
 
   Bot-readable. Each skill lives at /<topic>/SKILL.md
   Fetch any URL and read it into your context.
-  Example: fetch("https://ethskills.com/gas/SKILL.md")
+
+  All skills (116KB):  https://ethskills.com/SKILL.md
+
+  Individual skills:
+    https://ethskills.com/why/SKILL.md              — Why Ethereum
+    https://ethskills.com/gas/SKILL.md              — Gas & Costs
+    https://ethskills.com/wallets/SKILL.md          — Wallets
+    https://ethskills.com/l2s/SKILL.md              — Layer 2s
+    https://ethskills.com/standards/SKILL.md        — Standards
+    https://ethskills.com/tools/SKILL.md            — Tools
+    https://ethskills.com/building-blocks/SKILL.md  — Money Legos (DeFi)
+    https://ethskills.com/orchestration/SKILL.md    — Orchestration
+    https://ethskills.com/addresses/SKILL.md        — Contract Addresses
+    https://ethskills.com/concepts/SKILL.md         — Concepts
+    https://ethskills.com/security/SKILL.md         — Security
+    https://ethskills.com/frontend-ux/SKILL.md      — Frontend UX
+    https://ethskills.com/frontend-playbook/SKILL.md — Frontend Playbook
 -->
 
 <div class="ascii">

--- a/l2/SKILL.md
+++ b/l2/SKILL.md
@@ -1,0 +1,3 @@
+This skill has moved to [l2s/SKILL.md](https://ethskills.com/l2s/SKILL.md).
+
+Fetch the correct URL: https://ethskills.com/l2s/SKILL.md

--- a/layer2/SKILL.md
+++ b/layer2/SKILL.md
@@ -1,0 +1,3 @@
+This skill has moved to [l2s/SKILL.md](https://ethskills.com/l2s/SKILL.md).
+
+Fetch the correct URL: https://ethskills.com/l2s/SKILL.md


### PR DESCRIPTION
### Problem

Bots guessing paths from skill names hit 404s:
- "Layer 2s" → tries `/l2/SKILL.md` → 404 (actual: `/l2s/SKILL.md`)
- "Money Legos" → tries `/defi/SKILL.md` → 404 (actual: `/building-blocks/SKILL.md`)
- "Contract Addresses" → tries `/contracts/SKILL.md` → 404 (actual: `/addresses/SKILL.md`)

Also, the HTML comment that non-JS bots read only had one example URL — not the full list.

### Fix

1. **Redirect SKILL.md files** at guessable paths (`l2/`, `layer2/`, `defi/`, `contracts/`) that point bots to the correct URL
2. **Expanded HTML comment** now lists all 13 skill URLs so any bot reading the raw HTML source can discover every skill without rendering JavaScript

### Changes
- `l2/SKILL.md` → redirects to `l2s/SKILL.md`
- `layer2/SKILL.md` → redirects to `l2s/SKILL.md`
- `defi/SKILL.md` → redirects to `building-blocks/SKILL.md`
- `contracts/SKILL.md` → redirects to `addresses/SKILL.md`
- `index.html` — HTML comment now contains full skill URL index