### PR TITLE
Add YAML frontmatter to deprecated skill redirects

### DIFF
--- a/contracts/SKILL.md
+++ b/contracts/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: contracts
+description: "Deprecated: this skill has moved to addresses."
+---
+
 This skill has moved to [addresses/SKILL.md](https://ethskills.com/addresses/SKILL.md).
 
 Fetch the correct URL: https://ethskills.com/addresses/SKILL.md

--- a/defi/SKILL.md
+++ b/defi/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: defi
+description: "Deprecated: this skill has moved to building-blocks."
+---
+
 This skill has moved to [building-blocks/SKILL.md](https://ethskills.com/building-blocks/SKILL.md).
 
 Fetch the correct URL: https://ethskills.com/building-blocks/SKILL.md

--- a/l2/SKILL.md
+++ b/l2/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: l2
+description: "Deprecated: this skill has moved to l2s."
+---
+
 This skill has moved to [l2s/SKILL.md](https://ethskills.com/l2s/SKILL.md).
 
 Fetch the correct URL: https://ethskills.com/l2s/SKILL.md

--- a/layer2/SKILL.md
+++ b/layer2/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: layer2
+description: "Deprecated: this skill has moved to l2s."
+---
+
 This skill has moved to [l2s/SKILL.md](https://ethskills.com/l2s/SKILL.md).
 
 Fetch the correct URL: https://ethskills.com/l2s/SKILL.md


### PR DESCRIPTION
## Summary
- Adds `name` and `description` YAML frontmatter to the 4 deprecated skill redirect files (`contracts`, `defi`, `l2`, `layer2`)
- Makes these skills discoverable with metadata before the full file is fetched

## Test plan
- [ ] Verify frontmatter parses correctly (valid YAML between `---` delimiters)
- [ ] Confirm redirect content is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)