### PR TITLE
add QA skill + make frontend-ux rules louder on repeat offenders

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -21,6 +21,7 @@ For individual topics, fetch any of these directly:
 - [Security](https://ethskills.com/security/SKILL.md) — Smart contract security vulnerabilities and patterns
 - [Frontend UX](https://ethskills.com/frontend-ux/SKILL.md) — Frontend UX patterns for Ethereum dApps
 - [Frontend Playbook](https://ethskills.com/frontend-playbook/SKILL.md) — Step-by-step frontend build guide
+- [QA](https://ethskills.com/qa/SKILL.md) — Pre-ship audit checklist for a reviewer agent
 
 ---
 

--- a/frontend-ux/SKILL.md
+++ b/frontend-ux/SKILL.md
@@ -17,6 +17,8 @@ description: Frontend UX rules for Ethereum dApps that prevent the most common A
 
 ## Rule 1: Every Onchain Button — Loader + Disable
 
+> ⚠️ **THIS IS THE #1 BUG AI AGENTS SHIP.** The user clicks Approve, signs in their wallet, comes back to the app, and the Approve button is clickable again — so they click it again, send a duplicate transaction, and now two approvals are pending. **The button MUST be disabled and show a spinner from the moment they click until the transaction confirms onchain.** Not until the wallet closes. Not until the signature is sent. Until the BLOCK CONFIRMS.
+
 ANY button that triggers a blockchain transaction MUST:
 1. **Disable immediately** on click
 2. **Show a spinner** ("Approving...", "Staking...", etc.)
@@ -64,15 +66,18 @@ await writeContractAsync({...}); // Waits for actual onchain confirmation
 
 ---
 
-## Rule 2: Three-Button Flow — Network → Approve → Action
+## Rule 2: Four-State Flow — Connect → Network → Approve → Action
 
-When a user needs to approve tokens then perform an action (stake, deposit, swap), there are THREE states. Show exactly ONE button at a time:
+When a user needs to interact with the app, there are FOUR states. Show exactly ONE big, obvious button at a time:
 
 ```
-1. Wrong network?       → "Switch to Base" button
-2. Not enough approved? → "Approve" button  
-3. Enough approved?     → "Stake" / "Deposit" / action button
+1. Not connected?       → Big "Connect Wallet" button (NOT text saying "connect your wallet to play")
+2. Wrong network?       → Big "Switch to Base" button
+3. Not enough approved? → "Approve" button (with loader per Rule 1)
+4. Enough approved?     → "Stake" / "Deposit" / action button
 ```
+
+> **NEVER show a text prompt like "Connect your wallet to play" or "Please connect to continue."** Show a button. The user should always have exactly one thing to click.
 
 ```typescript
 const { data: allowance } = useScaffoldReadContract({
@@ -83,8 +88,11 @@ const { data: allowance } = useScaffoldReadContract({
 
 const needsApproval = !allowance || allowance < amount;
 const wrongNetwork = chain?.id !== targetChainId;
+const notConnected = !address;
 
-{wrongNetwork ? (
+{notConnected ? (
+  <RainbowKitCustomConnectButton />  // Big connect button — NOT text
+) : wrongNetwork ? (
   <button onClick={switchNetwork} disabled={isSwitching}>
     {isSwitching ? "Switching..." : "Switch to Base"}
   </button>
@@ -141,6 +149,17 @@ import { AddressInput } from "~~/components/scaffold-eth";
 `<AddressInput/>` provides ENS resolution (type "vitalik.eth" → resolves to address), blockie avatar preview, validation, and paste handling.
 
 **The pair: `<Address/>` for DISPLAY, `<AddressInput/>` for INPUT. Always.**
+
+### Show Your Contract Address
+
+**Every dApp should display its deployed contract address** at the bottom of the main page using `<Address/>`. Users want to verify the contract on a block explorer. This builds trust and is standard practice.
+
+```typescript
+<div className="text-center mt-8 text-sm opacity-70">
+  <p>Contract:</p>
+  <Address address={deployedContractAddress} />
+</div>
+```
 
 ---
 
@@ -251,13 +270,17 @@ export const metadata: Metadata = {
 - NOT an environment variable that could be unset
 - Actually reachable (test by visiting the URL in a browser)
 
+**Remove ALL Scaffold-ETH 2 default identity:**
+- [ ] README rewritten — not the SE2 template README
+- [ ] Footer cleaned — remove BuidlGuidl links, "Fork me" link, support links, any SE2 branding. Replace with your project's repo link
+- [ ] Favicon updated — not the SE2 default
+- [ ] Tab title is your app name — not "Scaffold-ETH 2"
+
 **Full checklist:**
 - [ ] OG image URL is absolute, live production domain
 - [ ] OG title and description set (not default SE2 text)
 - [ ] Twitter card type set (`summary_large_image`)
-- [ ] Favicon updated from SE2 default
-- [ ] README updated from SE2 default
-- [ ] Footer "Fork me" link → your actual repo (not SE2)
+- [ ] All SE2 default branding removed (README, footer, favicon, tab title)
 - [ ] Browser tab title is correct
 - [ ] RPC overrides set (not public RPCs)
 - [ ] `pollingInterval` is 3000

--- a/index.html
+++ b/index.html
@@ -268,6 +268,7 @@ h2 {
     https://ethskills.com/security/SKILL.md         — Security
     https://ethskills.com/frontend-ux/SKILL.md      — Frontend UX
     https://ethskills.com/frontend-playbook/SKILL.md — Frontend Playbook
+    https://ethskills.com/qa/SKILL.md               — QA (Pre-Ship Audit)
 -->
 
 <div class="ascii">
@@ -359,6 +360,12 @@ h2 {
   <div class="skill-name">Frontend Playbook</div>
   <div class="skill-desc">The complete build-to-production pipeline. Fork mode, IPFS deployment, Vercel monorepo config, ENS subdomain setup, and the full go-to-production checklist with verification steps.</div>
   <button class="copy-btn" data-url="https://ethskills.com/frontend-playbook/SKILL.md"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg> ethskills.com/frontend-playbook/SKILL.md</button>
+</div>
+
+<div class="skill">
+  <div class="skill-name">QA</div>
+  <div class="skill-desc">Production QA checklist for dApps. Give this to a SEPARATE reviewer agent after the build — it audits the app against every common mistake AI agents make before shipping. Covers approve button double-fire, wallet flow, SE2 branding cleanup, USD values, and more.</div>
+  <button class="copy-btn" data-url="https://ethskills.com/qa/SKILL.md"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg> ethskills.com/qa/SKILL.md</button>
 </div>
 
 <h2>How to Use</h2>

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: qa
+description: Pre-ship audit checklist for Ethereum dApps built with Scaffold-ETH 2. Give this to a separate reviewer agent (or fresh context) AFTER the build is complete. Covers only the bugs AI agents actually ship — validated by baseline testing against stock LLMs.
+---
+
+# dApp QA — Pre-Ship Audit
+
+This skill is for **review, not building.** Give it to a fresh agent after the dApp is built. The reviewer should:
+
+1. Read the source code (`app/`, `components/`, `contracts/`)
+2. Open the app in a browser and click through every flow
+3. Check every item below — report PASS/FAIL, don't fix
+
+---
+
+## 🚨 Critical: Wallet Flow — Button Not Text
+
+Open the app with NO wallet connected.
+
+- ❌ **FAIL:** Text saying "Connect your wallet to play" / "Please connect to continue" / any paragraph telling the user to connect
+- ✅ **PASS:** A big, obvious Connect Wallet **button** is the primary UI element
+
+**This is the most common AI agent mistake.** Every stock LLM writes a `<p>Please connect your wallet</p>` instead of rendering `<RainbowKitCustomConnectButton />`.
+
+---
+
+## 🚨 Critical: Four-State Button Flow
+
+The app must show exactly ONE primary button at a time, progressing through:
+
+```
+1. Not connected  → Connect Wallet button
+2. Wrong network  → Switch to [Chain] button
+3. Needs approval → Approve button
+4. Ready          → Action button (Stake/Deposit/Swap)
+```
+
+Check specifically:
+- ❌ **FAIL:** Approve and Action buttons both visible simultaneously
+- ❌ **FAIL:** No network check — app tries to work on wrong chain and fails silently
+- ❌ **FAIL:** User can click Approve, sign in wallet, come back, and click Approve again while tx is pending
+- ✅ **PASS:** One button at a time. Approve button shows spinner, stays disabled until block confirms onchain. Then switches to the action button.
+
+**In the code:** the button's `disabled` prop must be tied to `isPending` from `useScaffoldWriteContract`. Verify it uses `useScaffoldWriteContract` (waits for block confirmation), NOT raw wagmi `useWriteContract` (resolves on wallet signature):
+
+```
+grep -rn "useWriteContract" packages/nextjs/
+```
+Any match outside scaffold-eth internals → bug.
+
+---
+
+## 🚨 Critical: SE2 Branding Removal
+
+AI agents treat the scaffold as sacred and leave all default branding in place.
+
+- [ ] **Footer:** Remove BuidlGuidl links, "Built with 🏗️ SE2", "Fork me" link, support links. Replace with project's own repo link or clean it out
+- [ ] **Tab title:** Must be the app name, NOT "Scaffold-ETH 2" or "SE-2 App" or "App Name | Scaffold-ETH 2"
+- [ ] **README:** Must describe THIS project. Not the SE2 template README. Remove "Built with Scaffold-ETH 2" sections and SE2 doc links
+- [ ] **Favicon:** Must not be the SE2 default
+
+---
+
+## Important: Contract Address Display
+
+- ❌ **FAIL:** The deployed contract address appears nowhere on the page
+- ✅ **PASS:** Contract address displayed using `<Address/>` component (blockie, ENS, copy, explorer link)
+
+Agents display the connected wallet address but forget to show the contract the user is interacting with.
+
+---
+
+## Important: USD Values
+
+- ❌ **FAIL:** Token amounts shown as "1,000 TOKEN" or "0.5 ETH" with no dollar value
+- ✅ **PASS:** "0.5 ETH (~$1,250)" with USD conversion
+
+Agents never add USD values unprompted. Check every place a token or ETH amount is displayed, including inputs.
+
+---
+
+## Important: OG Image Must Be Absolute URL
+
+- ❌ **FAIL:** `images: ["/thumbnail.jpg"]` — relative path, breaks unfurling everywhere
+- ✅ **PASS:** `images: ["https://yourdomain.com/thumbnail.jpg"]` — absolute production URL
+
+Quick check:
+```
+grep -n "og:image\|images:" packages/nextjs/app/layout.tsx
+```
+
+---
+
+## Important: RPC & Polling Config
+
+Open `packages/nextjs/scaffold.config.ts`:
+
+- ❌ **FAIL:** `pollingInterval: 30000` (default — makes the UI feel broken, 30 second update lag)
+- ✅ **PASS:** `pollingInterval: 3000`
+- ❌ **FAIL:** Using default Alchemy API key that ships with SE2
+- ✅ **PASS:** `rpcOverrides` uses `process.env.NEXT_PUBLIC_*` variables
+
+---
+
+## Audit Summary
+
+Report each as PASS or FAIL:
+
+### Ship-Blocking
+- [ ] Wallet connection shows a BUTTON, not text
+- [ ] Wrong network shows a Switch button
+- [ ] One button at a time (Connect → Network → Approve → Action)
+- [ ] Approve button disabled with spinner through block confirmation
+- [ ] SE2 footer branding removed
+- [ ] SE2 tab title removed
+- [ ] SE2 README replaced
+
+### Should Fix
+- [ ] Contract address displayed with `<Address/>`
+- [ ] USD values next to all token/ETH amounts
+- [ ] OG image is absolute production URL
+- [ ] pollingInterval is 3000
+- [ ] RPC overrides set (not default SE2 key)
+- [ ] Favicon updated from SE2 default


### PR DESCRIPTION
## What this does

**New: `qa/SKILL.md`** — A standalone pre-ship audit checklist designed to be given to a **separate reviewer agent** (or fresh context) after the build. Covers only the bugs AI agents actually ship, validated by baseline testing.

**Changes to `frontend-ux/SKILL.md`:**
- Rule 1: Added critical callout for approve button double-fire
- Rule 2: Expanded from three-state to four-state flow: **Connect → Network → Approve → Action**
- Rule 3: Added "Show Your Contract Address" section
- Rule 7: Added explicit SE2 branding removal checklist

## Triage methodology

Ran baseline tests against stock Sonnet 4.5 (no tools, no skills, pure training data). Asked it to build a production-ready SE2 staking dApp.

**Verified blind spots (kept):**
- Wallet connection: writes `<p>Please connect your wallet</p>` instead of a button ❌
- Network switching: zero handling ❌
- Approve double-fire: both buttons visible simultaneously ❌
- SE2 branding: left entire stock footer, tab title, README intact ❌
- OG image: relative URL ❌
- USD values: zero ❌
- Contract address display: shows wallet address, not contract ❌
- pollingInterval: left at 30000 ❌
- RPC overrides: default Alchemy key ❌

**Training-data-tier knowledge (cut):**
- formatEther/parseEther ✅ — used correctly
- useScaffoldWriteContract ✅ — chose it over raw wagmi
- Loading spinners ✅ — had them
- `<Address/>` component ✅ — used it
- Mobile responsive ✅ — did naturally
- .env in .gitignore ✅ — already handled by SE2

**Result: QA skill went from 205 lines → 124 lines.** Every surviving line is a verified LLM blind spot.

Full methodology: [triage-methodology.md](https://github.com/austintgriffith/ethskills-research/blob/master/research/triage-methodology.md)