### PR TITLE
fix: use yarn vercel instead of cd packages/nextjs && vercel

### DIFF
--- a/orchestration/SKILL.md
+++ b/orchestration/SKILL.md
@@ -181,7 +181,7 @@ Note: IPFS only works with static content — no server-side rendering, API endp
 
 **Vercel:**
 ```bash
-cd packages/nextjs && vercel
+yarn vercel
 ```
 
 ### Production QA


### PR DESCRIPTION
## Summary

- SE2's root `package.json` has a `vercel` script: `yarn workspace @se-2/nextjs vercel`
- Replace `cd packages/nextjs && vercel` with just `yarn vercel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)