### PR TITLE
fix: Aerodrome/Velodrome → Aero (merged Nov 2025)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -60,7 +60,7 @@ L2 landscape, bridging, deployment differences.
 - Base is the cheapest major L2. Arbitrum has the deepest DeFi liquidity.
 - Celo is NOT an L1 anymore — migrated to OP Stack L2 in March 2025.
 - Polygon zkEVM is being shut down. Do not build on it.
-- The dominant DEX on each L2 is NOT Uniswap (Aerodrome on Base, Velodrome on Optimism).
+- The dominant DEX on each L2 is NOT Uniswap (Aero on Base and Optimism — Aerodrome and Velodrome merged Nov 2025).
 
 ### [Standards](https://ethskills.com/standards/SKILL.md)
 ERC-20, ERC-721, ERC-8004, EIP-7702, x402.
@@ -78,7 +78,7 @@ Foundry, Scaffold-ETH 2, Blockscout MCP, x402 SDKs.
 Uniswap, Aave, flash loans, protocol composability.
 - Uniswap V4 hooks: custom logic attached to pools (dynamic fees, TWAMM, limit orders).
 - Flash loan arb on mainnet costs ~$0.05-0.50 in gas now (was $5-50).
-- The dominant DEX per L2 is NOT Uniswap — Aerodrome (Base), Velodrome (Optimism), Camelot (Arbitrum).
+- The dominant DEX per L2 is NOT Uniswap — Aero (Base + Optimism, merged from Aerodrome/Velodrome Nov 2025), Camelot (Arbitrum).
 
 ### [Orchestration](https://ethskills.com/orchestration/SKILL.md)
 Three-phase build system for Scaffold-ETH 2 dApps.

--- a/building-blocks/SKILL.md
+++ b/building-blocks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: building-blocks
-description: DeFi legos and protocol composability on Ethereum and L2s. Major protocols per chain — Aerodrome on Base, GMX/Pendle on Arbitrum, Velodrome on Optimism — plus mainnet primitives (Uniswap, Aave, Compound, Curve). How they work, how to build on them, and how to combine them. Use when building DeFi integrations, choosing protocols on a specific L2, designing yield strategies, or composing existing protocols into something new.
+description: DeFi legos and protocol composability on Ethereum and L2s. Major protocols per chain — Aero on Base and Optimism (Aerodrome + Velodrome merged Nov 2025), GMX/Pendle on Arbitrum, plus mainnet primitives (Uniswap, Aave, Compound, Curve). How they work, how to build on them, and how to combine them. Use when building DeFi integrations, choosing protocols on a specific L2, designing yield strategies, or composing existing protocols into something new.
 ---
 
 # Building Blocks (DeFi Legos)


### PR DESCRIPTION
## What

Updates two stale references in the index (`SKILL.md` / `llms.txt` / `CLAUDE.md` — same file via symlinks) and the `building-blocks` frontmatter description.

The body of `building-blocks/SKILL.md` and `l2s/SKILL.md` already correctly describe the merger. These were the remaining stale summary lines.

## Source

[CoinDesk Nov 13 2025](https://www.coindesk.com/tech/2025/11/13/leading-base-dex-aerodrome-merges-into-aero-in-major-overhaul): Dromos Labs merged Aerodrome (Base) and Velodrome (Optimism) into "Aero"

[The Defiant](https://thedefiant.io/news/defi/dromos-labs-merges-aerodrome-and-velodrome-into-new-dex-aero): confirms brand unification

## Changes

3 lines. No protocol content touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)