### PR TITLE
question for nixo: add Hegota to protocol fork table?

### DIFF
--- a/protocol/SKILL.md
+++ b/protocol/SKILL.md
@@ -123,6 +123,7 @@ Hard forks are how Ethereum upgrades. Recent and upcoming:
 | Pectra | May 7, 2025 | EIP-7702 (smart EOAs), validator consolidation (EIP-7251) |
 | Fusaka | Dec 3, 2025 | PeerDAS (EIP-7594), more blobs (EIP-7892) |
 | Glamsterdam | ~Q3-Q4 2026 (in progress) | ePBS (EIP-7732), block access lists (EIP-7928) |
+| Hegota | ~Q4 2026 (early planning) | TBD — check [forkcast.org/upgrade/hegota](https://forkcast.org/upgrade/hegota) for confirmed scope |
 
 **To find what's in a fork:**
 1. Check [forkcast.org](https://forkcast.org) — filter by fork to see all CFI/SFI EIPs


### PR DESCRIPTION
## Question for nixo

`why/SKILL.md` mentions "Hegota (Q4 2026)" but it's absent from the fork table in `protocol/SKILL.md`. An agent reading only `protocol/` has no idea Hegota exists.

**The change:** adds one row — intentionally left as "TBD, check forkcast.org" because I ran into a contradiction I can't resolve:

- `why/SKILL.md` says Hegota will NOT have Verkle Trees (binary tree EIP-7864 instead, quantum resistance)
- Multiple news sources (CoinDesk, Phemex, KuCoin) say Hegota WILL have Verkle Trees
- I can't render forkcast.org to check

**Questions for nixo:**
1. Should Hegota be in this table?
2. If yes — what should "Notable Changes" say? Verkle Trees, or the binary tree direction?
3. Is the timing "~Q4 2026" roughly right?

Do not merge without nixo's input on the content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)