### PR TITLE
wallets: remove duplicate EIP-7702 delegation persistence note

### DIFF
--- a/wallets/SKILL.md
+++ b/wallets/SKILL.md
@@ -15,7 +15,7 @@ description: How to create, manage, and use Ethereum wallets. Covers EOAs, smart
 
 ## EIP-7702: Smart EOAs (Live Since May 2025)
 
-EOAs can **authorize delegated code execution** from smart-contract code. This is not automatically "one and done" - the delegation can stay active until it is replaced or explicitly cleared.
+EOAs can **authorize delegated code execution** from smart-contract code.
 
 **How it works:**
 1. The wallet signs a message that says which contract code the EOA can use.


### PR DESCRIPTION
The persistence caveat ("not automatically 'one and done'...") appeared both in the section intro and in step 4 of the numbered list. Removed from the intro and kept in step 4, where step 5 already builds on it.