### PR TITLE
fix: update Foundry vs Hardhat claim to reflect Hardhat 3

### DIFF
--- a/tools/SKILL.md
+++ b/tools/SKILL.md
@@ -13,7 +13,7 @@ description: Current Ethereum development tools, frameworks, libraries, RPCs, an
 
 **x402 has production SDKs:** `@x402/fetch` (TS), `x402` (Python), `github.com/coinbase/x402/go` — production-ready libraries for HTTP payments.
 
-**Foundry is the default for new projects in 2026.** Uniswap v4, Aave v4, and every major audit firm use it. Note: Hardhat 3 (Aug 2025) now has Solidity testing and fuzzing too — consider it if your team lives in TypeScript.
+**Foundry is the default for new projects in 2026.** Note: Hardhat 3 (Aug 2025) now has Solidity testing and fuzzing too — consider it if your team lives in TypeScript.
 
 ## Tool Discovery Pattern for AI Agents
 

--- a/tools/SKILL.md
+++ b/tools/SKILL.md
@@ -13,7 +13,7 @@ description: Current Ethereum development tools, frameworks, libraries, RPCs, an
 
 **x402 has production SDKs:** `@x402/fetch` (TS), `x402` (Python), `github.com/coinbase/x402/go` — production-ready libraries for HTTP payments.
 
-**Foundry is the default for new projects in 2026.** Not Hardhat. 10-100x faster tests, Solidity-native testing, built-in fuzzing.
+**Foundry is the default for new projects in 2026.** Uniswap v4, Aave v4, and every major audit firm use it. Note: Hardhat 3 (Aug 2025) now has Solidity testing and fuzzing too — consider it if your team lives in TypeScript.
 
 ## Tool Discovery Pattern for AI Agents
 

--- a/tools/SKILL.md
+++ b/tools/SKILL.md
@@ -79,7 +79,7 @@ const response = await x402Fetch('https://api.example.com/data', {
 | Need | Tool |
 |------|------|
 | Rapid prototyping / full dApps | **Scaffold-ETH 2** |
-| Contract-focused dev | **Foundry** (forge + cast + anvil) |
+| Contract-focused dev | **Foundry** (forge + cast + anvil) · or **Hardhat 3** if TypeScript-first |
 | Quick contract interaction | **abi.ninja** (browser) or **cast** (CLI) |
 | React frontends | **wagmi + viem** (or SE2 which wraps these) |
 | Agent blockchain reads | **Blockscout MCP** |


### PR DESCRIPTION
## Summary

- Drop "10-100x faster" — stale benchmark from before Hardhat 3
- Drop "Not Hardhat" / "Hardhat still works" framing sitewide
- Hardhat 3 (Aug 2025) ships Solidity testing, fuzzing, and Rust internals — it's a real option now
- Keep "Foundry is the default" — still true for protocol/DeFi work

🤖 Generated with [Claude Code](https://claude.com/claude-code)