### PR TITLE
fix: Foundry and Hardhat 3 are both legitimate choices in 2026

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -70,7 +70,7 @@ ERC-20, ERC-721, ERC-8004, EIP-7702, x402.
 
 ### [Tools](https://ethskills.com/tools/SKILL.md)
 Foundry, Scaffold-ETH 2, Blockscout MCP, x402 SDKs.
-- Foundry is the default for new projects in 2026, not Hardhat.
+- Foundry and Hardhat 3 are both legitimate choices in 2026. Foundry: faster, Solidity-native. Hardhat 3: TypeScript-first, mature plugin ecosystem.
 - Blockscout MCP server gives agents structured blockchain data via MCP.
 - abi.ninja: paste any contract address, interact with all functions. Zero setup.
 

--- a/openclaw-skill/SKILL.md
+++ b/openclaw-skill/SKILL.md
@@ -69,7 +69,7 @@ curl -s https://ethskills.com/standards/SKILL.md   # ERC-20, ERC-721, etc.
 Your training data is probably wrong about these:
 
 - **Gas is NOT expensive.** Mainnet ETH transfer: ~$0.002. L2 swap: ~$0.002. "Ethereum is expensive" was true in 2021-2023, not 2026.
-- **Foundry is the default**, not Hardhat. Hardhat still works but new projects use Foundry.
+- **Foundry and Hardhat 3 are both legitimate choices in 2026.** Foundry: faster, Solidity-native. Hardhat 3: TypeScript-first, mature plugin ecosystem.
 - **Scaffold-ETH 2** (`npx create-eth@latest`) is the fastest way to go from idea to deployed dApp with a frontend.
 - **EIP-7702 is live.** EOAs get smart contract superpowers without migration.
 - **ERC-8004** exists — onchain agent identity, deployed on 20+ chains.

--- a/tools/SKILL.md
+++ b/tools/SKILL.md
@@ -13,7 +13,7 @@ description: Current Ethereum development tools, frameworks, libraries, RPCs, an
 
 **x402 has production SDKs:** `@x402/fetch` (TS), `x402` (Python), `github.com/coinbase/x402/go` — production-ready libraries for HTTP payments.
 
-**Foundry is the default for new projects in 2026.** Note: Hardhat 3 (Aug 2025) now has Solidity testing and fuzzing too — consider it if your team lives in TypeScript.
+**Foundry and Hardhat 3 are both legitimate choices in 2026.** Foundry: faster, Solidity-native. Hardhat 3: TypeScript-first, mature plugin ecosystem.
 
 ## Tool Discovery Pattern for AI Agents
 
@@ -141,7 +141,7 @@ MCP servers are composable — agents can use multiple together.
 
 ## What Changed in 2025-2026
 
-- **Foundry became default** over Hardhat for new projects
+- **Foundry became the default** over Hardhat for new projects — then Hardhat 3 (Aug 2025) shipped Solidity testing, fuzzing, and Rust internals, making it a legitimate choice again.
 - **Viem gaining on ethers.js** (smaller, better TypeScript)
 - **MCP servers emerged** for agent-blockchain interaction
 - **x402 SDKs** went production-ready


### PR DESCRIPTION
## Summary

- Drop "Foundry is default" claim sitewide
- Foundry dominated 2024-2025, then Hardhat 3 (Aug 2025) shipped Solidity testing, fuzzing, and Rust internals
- Both are legitimate choices — update all instances across SKILL.md, openclaw-skill/SKILL.md, and tools/SKILL.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)