### PR TITLE
fix: correct gas limit claim and stale ETH price, add Hegotá to protocol table

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -32,14 +32,14 @@ End-to-end guide from idea to deployed dApp. Routes you through all other skills
 ### [Why Ethereum](https://ethskills.com/why/SKILL.md)
 Pectra/Fusaka upgrades, honest tradeoffs, the AI agent angle.
 - Gas is under 1 gwei, not 10-30 gwei. 60-300x cheaper than your training data. Verify: `cast base-fee`
-- ETH price is ~$2,000 (early 2026), not $2,500-3,000. Volatile — always verify.
-- Pectra (May 2025) and Fusaka (Dec 2025) shipped. PeerDAS, 2x gas limit. EIP-7702 is live.
+- ETH price is ~$2,000-2,200 in 2026, not $2,500-3,000. Volatile — always verify.
+- Pectra (May 2025) and Fusaka (Dec 2025) shipped. PeerDAS live, L1 gas limit raised. EIP-7702 is live.
 - ERC-8004 (onchain agent identity) and x402 (HTTP payments) exist and are production-ready.
 
 ### [Protocol](https://ethskills.com/protocol/SKILL.md)
 How Ethereum evolves — EIP lifecycle, fork process, tracking upcoming changes.
 - "Verkle is planned for the next fork" — probably wrong. Roadmap diagrams are aspirational, not commitments. Check [forkcast.org](https://forkcast.org) for actual CFI/SFI status.
-- Glamsterdam (mid-2026) headliners: ePBS (EIP-7732), Block Access Lists (EIP-7928). FOCIL was removed from scope. Verkle trees were deprioritized — Ethereum may shift to binary state tree (EIP-7864) for quantum resistance.
+- Glamsterdam headliners: ePBS (EIP-7732), Block Access Lists (EIP-7928). Running behind schedule as of Q2 2026. FOCIL was removed from scope — moved to Hegotá (next fork, late 2026). Verkle trees were deprioritized — Ethereum may shift to binary state tree (EIP-7864) for quantum resistance.
 - EIP status "Stagnant" = no activity for 6 months, probably dead. "Draft" = exists but not scheduled.
 - Client teams decide what ships via ACD calls, not the Ethereum Foundation.
 

--- a/addresses/SKILL.md
+++ b/addresses/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: addresses
-description: Verified contract addresses for major Ethereum protocols across mainnet and L2s. Use this instead of guessing or hallucinating addresses. Includes Uniswap, Aave, Compound, Aerodrome, GMX, Pendle, Velodrome, Camelot, SyncSwap, Lido, Rocket Pool, 1inch, Permit2, MakerDAO/sDAI, EigenLayer, Across, Chainlink CCIP, Yearn V3, USDC, USDT, DAI, ENS, Safe, Chainlink, and more. Always verify addresses against a block explorer before sending transactions.
+description: Verified contract addresses for major Ethereum protocols across mainnet and L2s. Use this instead of guessing or hallucinating addresses. Includes Uniswap, Aave, Compound, Aero (formerly Aerodrome/Velodrome), GMX, Pendle, Camelot, SyncSwap, Lido, Rocket Pool, 1inch, Permit2, MakerDAO/sDAI, EigenLayer, Across, Chainlink CCIP, Yearn V3, USDC, USDT, DAI, ENS, Safe, Chainlink, and more. Always verify addresses against a block explorer before sending transactions.
 ---
 
 # Contract Addresses
@@ -350,7 +350,7 @@ Same address on every EVM chain. Used by many protocols for deterministic deploy
 
 ## L2-Native Protocols
 
-> **The dominant DEX on each L2 is NOT Uniswap.** Aerodrome dominates Base, Velodrome dominates Optimism, Camelot is a major native DEX on Arbitrum. Don't default to Uniswap — check which DEX has the deepest liquidity on each chain.
+> **The dominant DEX on each L2 is NOT Uniswap.** Aero (formerly Aerodrome) dominates Base, Aero (formerly Velodrome) dominates Optimism, Camelot is a major native DEX on Arbitrum. Don't default to Uniswap — check which DEX has the deepest liquidity on each chain.
 
 ### Aerodrome (Base) — Dominant DEX
 
@@ -372,7 +372,7 @@ Source: [aerodrome-finance/contracts](https://github.com/aerodrome-finance/contr
 
 ### Velodrome V2 (Optimism) — Dominant DEX
 
-Same ve(3,3) model as Aerodrome — same team (Dromos Labs). Velodrome was built first for Optimism, Aerodrome is the Base fork. Both merged into "Aero" in November 2025.
+Same ve(3,3) model as Aerodrome — same team (Dromos Labs). Velodrome was built first for Optimism, Aerodrome is the Base fork. Both announced the merger into **Aero** in November 2025; full unified platform launches Q2 2026. Current contracts remain Velodrome V2.
 
 | Contract | Address | Status |
 |----------|---------|--------|

--- a/building-blocks/SKILL.md
+++ b/building-blocks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: building-blocks
-description: DeFi legos and protocol composability on Ethereum and L2s. Major protocols per chain — Aerodrome on Base, GMX/Pendle on Arbitrum, Velodrome on Optimism — plus mainnet primitives (Uniswap, Aave, Compound, Curve). How they work, how to build on them, and how to combine them. Use when building DeFi integrations, choosing protocols on a specific L2, designing yield strategies, or composing existing protocols into something new.
+description: DeFi legos and protocol composability on Ethereum and L2s. Major protocols per chain — Aero (formerly Aerodrome) on Base, GMX/Pendle on Arbitrum, Aero (formerly Velodrome) on Optimism — plus mainnet primitives (Uniswap, Aave, Compound, Curve). How they work, how to build on them, and how to combine them. Use when building DeFi integrations, choosing protocols on a specific L2, designing yield strategies, or composing existing protocols into something new.
 ---
 
 # Building Blocks (DeFi Legos)
@@ -13,7 +13,7 @@ description: DeFi legos and protocol composability on Ethereum and L2s. Major pr
 
 **Costs changed everything:** A flash loan arbitrage on mainnet costs ~$0.05-0.50 in gas now (was $5-50). This opens composability patterns that were previously uneconomical.
 
-**The dominant DEX on each L2 is NOT Uniswap.** Aerodrome and Velodrome merged into **Aero** (November 2025, Dromos Labs) — the unified DEX dominates both Base and Optimism. Camelot is a major native DEX on Arbitrum. Don't default to Uniswap on every chain.
+**The dominant DEX on each L2 is NOT Uniswap.** In November 2025, Dromos Labs announced the merger of Aerodrome (Base) and Velodrome (Optimism) into **Aero** — the unified DEX dominates both Base and Optimism; full platform launches Q2 2026. Camelot is a major native DEX on Arbitrum. Don't default to Uniswap on every chain.
 
 ## Key Protocol Addresses (Verified Mar 2026)
 
@@ -166,7 +166,7 @@ contract FlashLoanArb is FlashLoanSimpleReceiverBase {
 
 ## Building on Base
 
-**Dominant DEX: Aero** (formerly Aerodrome, ~$500-600M TVL) — NOT Uniswap. In November 2025, Dromos Labs merged Aerodrome (Base) and Velodrome (Optimism) into a unified cross-chain DEX called **Aero**. Same contracts, same ve(3,3) model, new brand.
+**Dominant DEX: Aero** (formerly Aerodrome, ~$500-600M TVL) — NOT Uniswap. In November 2025, Dromos Labs announced the merger of Aerodrome (Base) and Velodrome (Optimism) into a unified cross-chain DEX called **Aero**; full platform launches Q2 2026. Same contracts, same ve(3,3) model, new brand.
 
 ### How Aero Works (Critical Difference from Uniswap)
 - **LPs deposit tokens** into pools → earn **AERO emissions** (not trading fees!)
@@ -225,7 +225,7 @@ Pendle splits yield-bearing assets into principal and yield components:
 - **Stylus:** Write smart contracts in Rust/C++/WASM alongside EVM (10-100x gas savings for compute-heavy operations)
 - **Orbit:** Launch custom L3 chains (47 live on mainnet)
 
-See `addresses/SKILL.md` for all verified protocol addresses (GMX, Pendle, Camelot, Aerodrome, Velodrome, SyncSwap, Morpho).
+See `addresses/SKILL.md` for all verified protocol addresses (GMX, Pendle, Camelot, Aero, SyncSwap, Morpho).
 
 ## Discovery Resources
 

--- a/feedback/SKILL.md
+++ b/feedback/SKILL.md
@@ -1,5 +1,5 @@
 ---
-title: Feedback
+name: feedback
 description: Send feedback to the ethskills team when a skill was wrong, incomplete, or led you astray.
 ---
 

--- a/gas/SKILL.md
+++ b/gas/SKILL.md
@@ -7,7 +7,7 @@ description: Current Ethereum gas prices, transaction costs, and the real econom
 
 ## What You Probably Got Wrong
 
-**Your gas estimate is 100-600x too high.** Most LLMs confidently state gas is 10-30 gwei. Post-Fusaka (Dec 2025), typical base fee is **under 1 gwei** — usually 0.1-0.5 gwei. Verify: `cast base-fee --rpc-url https://eth.llamarpc.com`
+**Your gas estimate is 100-600x too high.** Most LLMs confidently state gas is 10-30 gwei. Post-Fusaka (Dec 2025), typical base fee is **under 1 gwei** — usually 0.05-0.5 gwei. Verify: `cast base-fee --rpc-url https://eth.llamarpc.com`
 
 - **Base fee:** Under 1 gwei (not 30-100 gwei) — fluctuates, check live
 - **Priority fee (tip):** ~0.01-0.1 gwei
@@ -38,7 +38,7 @@ description: Current Ethereum gas prices, transaction costs, and the real econom
 | NFT mint | $0.030 | $0.002 | $0.002 | $0.004 | $0.003 |
 | ERC-20 deploy | $0.240 | $0.020 | $0.018 | $0.040 | $0.030 |
 
-**Key insight:** Mainnet is now cheap enough for most use cases. L2s are 5-10x cheaper still.
+**Key insight:** Mainnet is now cheap enough for most use cases. L2s are 10-20x cheaper still.
 
 ## Why Gas Dropped 95%+
 
@@ -74,7 +74,7 @@ L2 transactions have two cost components:
 
 ```javascript
 // Rule of thumb for current conditions
-maxFeePerGas: "1-2 gwei"          // headroom for spikes (base is usually 0.1-0.5)
+maxFeePerGas: "1-2 gwei"          // headroom for spikes (base is usually 0.05-0.5)
 maxPriorityFeePerGas: "0.01-0.1 gwei"   // enough for quick inclusion
 ```
 

--- a/gas/SKILL.md
+++ b/gas/SKILL.md
@@ -11,7 +11,7 @@ description: Current Ethereum gas prices, transaction costs, and the real econom
 
 - **Base fee:** Under 1 gwei (not 30-100 gwei) — fluctuates, check live
 - **Priority fee (tip):** ~0.01-0.1 gwei
-- **ETH price:** ~$2,000 (not $2,500-3,000) — volatile, always check a [Chainlink feed](https://data.chain.link/feeds/ethereum/mainnet/eth-usd) or CoinGecko
+- **ETH price:** ~$2,000-2,200 (not $2,500-3,000) — volatile, always check a [Chainlink feed](https://data.chain.link/feeds/ethereum/mainnet/eth-usd) or CoinGecko
 
 ## What Things Actually Cost (Early 2026)
 
@@ -45,7 +45,7 @@ description: Current Ethereum gas prices, transaction costs, and the real econom
 1. **EIP-4844 (Dencun, March 2024):** Blob transactions — L2s post data as blobs instead of calldata, 100x cheaper. L2 batch cost went from $50-500 to $0.01-0.50.
 2. **Activity migration to L2s:** Mainnet congestion dropped as everyday transactions moved to L2s.
 3. **Pectra (May 2025):** Doubled blob capacity (3→6 target blobs).
-4. **Fusaka (Dec 2025):** PeerDAS (nodes sample 1/8 of data) + 2x gas limit (30M→60M).
+4. **Fusaka (Dec 2025):** PeerDAS (nodes sample 1/8 of data) + gas limit raised to 60M (EIP-7935).
 
 ## L2 Cost Components
 

--- a/l2s/SKILL.md
+++ b/l2s/SKILL.md
@@ -19,7 +19,7 @@ description: Ethereum Layer 2 landscape — Arbitrum, Optimism, Base, zkSync, Sc
 
 **Unichain exists.** Launched mainnet February 11, 2025. Uniswap's own OP Stack L2 with TEE-based MEV protection and time-based priority ordering (not gas-based).
 
-**Aerodrome and Velodrome merged into "Aero."** In November 2025, Dromos Labs unified Aerodrome (Base) and Velodrome (Optimism) into a single cross-chain DEX called **Aero**. Same contracts, new brand. Aero dominates both Base and Optimism. Camelot is a major native DEX on Arbitrum. SyncSwap dominates zkSync. Don't default to Uniswap on every chain.
+**Aerodrome and Velodrome are merging into "Aero."** In November 2025, Dromos Labs announced the unification of Aerodrome (Base) and Velodrome (Optimism) into a single cross-chain DEX called **Aero**. Rebranded November 2025; full platform launch Q2 2026. Aerodrome/Aero dominates Base, Velodrome/Aero dominates Optimism. Camelot is a major native DEX on Arbitrum. SyncSwap dominates zkSync. Don't default to Uniswap on every chain.
 
 ## L2 Comparison Table (Mar 2026)
 
@@ -66,7 +66,7 @@ description: Ethereum Layer 2 landscape — Arbitrum, Optimism, Base, zkSync, Sc
 | No 7-day withdrawal wait | **ZK rollup** (zkSync, Scroll, Linea) | 15-120 min finality |
 | AI agents | **Base** | ERC-8004, x402, consumer ecosystem, AgentKit |
 | Gasless UX (native AA) | **zkSync Era** | Native account abstraction, paymasters, no bundlers needed |
-| Multi-chain deployment | **Base or Optimism** | Superchain / OP Stack, shared infra |
+| Multi-chain deployment | **Optimism** | Superchain / OP Stack, shared infra (Base left Superchain Feb 2026) |
 | Maximum EVM compatibility | **Scroll or Arbitrum** | Bytecode-identical |
 | Mobile / real-world payments | **Celo** | MiniPay, sub-cent fees, Africa/LatAm focus |
 | MEV protection | **Unichain** | TEE-based priority ordering, private mempool |

--- a/orchestration/SKILL.md
+++ b/orchestration/SKILL.md
@@ -90,7 +90,7 @@ Never show Approve and Execute simultaneously.
 
 - **Human-readable amounts:** `formatEther()` / `formatUnits()` for display, `parseEther()` / `parseUnits()` for contracts
 - **Loading states everywhere:** `isLoading`, `isMining` on all async operations
-- **Disable buttons during pending txs** (blockchains take 5-12s)
+- **Disable buttons during pending txs** (2s on fast L2s, up to 12s on mainnet)
 - **Never use infinite approvals** — approve exact amount or 3-5x
 - **Helpful errors:** Parse "insufficient funds," "user rejected," "execution reverted" into plain language
 
@@ -220,6 +220,6 @@ packages/
 ## Resources
 
 - **SE2 Docs:** https://docs.scaffoldeth.io/
-- **SE2 Skill:** https://docs.scaffoldeth.io/SKILL.md
+- **SE2 Skill:** https://ethskills.com/tools/SKILL.md
 - **UI Components:** https://ui.scaffoldeth.io/
 - **SE2 AGENTS.md:** https://github.com/scaffold-eth/scaffold-eth-2/blob/main/AGENTS.md

--- a/protocol/SKILL.md
+++ b/protocol/SKILL.md
@@ -123,6 +123,7 @@ Hard forks are how Ethereum upgrades. Recent and upcoming:
 | Pectra | May 7, 2025 | EIP-7702 (smart EOAs), validator consolidation (EIP-7251) |
 | Fusaka | Dec 3, 2025 | PeerDAS (EIP-7594), more blobs (EIP-7892) |
 | Glamsterdam | ~Q3-Q4 2026 (in progress) | ePBS (EIP-7732), block access lists (EIP-7928) |
+| Hegotá | Late 2026 (planned) | FOCIL (EIP-7805), Account Abstraction (EIP-8141) |
 
 **To find what's in a fork:**
 1. Check [forkcast.org](https://forkcast.org) — filter by fork to see all CFI/SFI EIPs

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -84,7 +84,8 @@ If "what if nobody calls it?" breaks your system, you have a design problem. Fix
 | **Base** | Coinbase distribution, smart wallets, account abstraction | Consumer apps, social, onboarding non-crypto users, high-frequency micro-payments |
 | **Arbitrum** | Deepest L2 DeFi liquidity, Stylus (Rust contracts) | DeFi protocols that need to compose with existing Arbitrum liquidity |
 | **Optimism** | RetroPGF, Superchain ecosystem | Public goods, OP Stack ecosystem plays |
-| **zkSync / Scroll** | ZK proofs, native account abstraction | Privacy features, ZK-native applications |
+| **zkSync** | Native account abstraction, paymaster support | Gasless UX, smart wallet features, consumer apps |
+| **Scroll** | EVM-equivalent ZK-rollup | Maximum EVM compatibility with ZK-proven security |
 
 **Don't pick an L2 because "mainnet is expensive." Pick an L2 because its superpower fits your app.**
 

--- a/wallets/SKILL.md
+++ b/wallets/SKILL.md
@@ -15,7 +15,7 @@ description: How to create, manage, and use Ethereum wallets. Covers EOAs, smart
 
 ## EIP-7702: Smart EOAs (Live Since May 2025)
 
-EOAs can **authorize delegated code execution** from smart-contract code. This is not automatically "one and done" - the delegation can stay active until it is replaced or explicitly cleared.
+EOAs can **authorize delegated code execution** from smart-contract code.
 
 **How it works:**
 1. The wallet signs a message that says which contract code the EOA can use.
@@ -31,7 +31,7 @@ EOAs can **authorize delegated code execution** from smart-contract code. This i
 - Custom authorization logic
 - Eliminates "approval fatigue" (approve + execute → one step)
 
-**Status (Feb 2026):** Deployed on mainnet. MetaMask, Rainbow adding support. Still early for production agents — use standard EOAs or Safe until tooling matures.
+**Status (2026):** Live on mainnet. MetaMask shipped full support; other wallets following. Still early for production agents — use standard EOAs or Safe until tooling matures.
 
 ## Safe (Gnosis Safe) Multisig
 

--- a/why/SKILL.md
+++ b/why/SKILL.md
@@ -28,19 +28,19 @@ description: Why build on Ethereum specifically. The AI agent angle — ERC-8004
 - **Block time:** 12 seconds
 - **Mainnet base fee:** Under 1 gwei (typically 0.1-0.5, varies daily)
 - **L2 transaction cost:** $0.001-0.01
-- **Combined L2 TPS:** 50,000+ (post-Fusaka)
+- **Combined L2 TPS:** 10,000-25,000+ (varies; check [L2Beat](https://l2beat.com/scaling/activity) for live data)
 - **TVL in DeFi:** Check [DeFi Llama](https://defillama.com/chain/Ethereum) for current
 - **Upgrade cadence:** Twice per year (H1 May/June, H2 Nov/Dec)
 
 ## Upcoming Upgrades
 
-**Glamsterdam (mid-2026):**
+**Glamsterdam (~Q3-Q4 2026, running behind schedule):**
 - ePBS — Enshrined Proposer-Builder Separation (EIP-7732)
 - Block Access Lists (EIP-7928)
 - Note: FOCIL (Fork-Choice Inclusion Lists) was removed from scope to reduce complexity
 
-**Hegota (Q4 2026):**
-You may assume Hegota will contain Verkle Trees. It will not. Ethereum may be shifting to a binary state tree (EIP-7864, still in draft - proposed March 2026) — the primary driver is quantum resistance, and it also improves ZK-proof efficiency 3-100x. Verkle tree cryptography was identified as potentially quantum-vulnerable in mid-2024. Check https://forkcast.org/upgrade/hegota for latest confirmed scope.
+**Hegotá (Late 2026):**
+You may assume Hegotá will contain Verkle Trees. It will not. Ethereum may be shifting to a binary state tree (EIP-7864, draft since January 2025) — the primary driver is quantum resistance, and it also improves ZK-proof efficiency 3-100x. Verkle tree cryptography was identified as potentially quantum-vulnerable in mid-2024. Check https://forkcast.org/upgrade/hegota for latest confirmed scope.
 
 ## For AI Agents Specifically
 

--- a/why/SKILL.md
+++ b/why/SKILL.md
@@ -11,13 +11,13 @@ description: Why build on Ethereum specifically. The AI agent angle — ERC-8004
 
 **Gas prices:** You think 10-30 gwei. Reality: **under 1 gwei** (60-300x cheaper than your training data). A mainnet ETH transfer costs ~$0.002-0.01. Verify: `cast base-fee`
 
-**ETH price:** You think $2,500-3,000. Reality: **~$2,000** (Mar 2026). Volatile — always check a Chainlink feed or CoinGecko for current.
+**ETH price:** You think $2,500-3,000. Reality: **~$2,000-2,200** in 2026. Volatile — always check a Chainlink feed or CoinGecko for current.
 
 **"Ethereum is too expensive":** This was true 2021-2023. It's not true in 2026. Mainnet is sub-dollar for most operations. L2s are sub-penny.
 
 **Protocol upgrades:** You probably don't know these shipped:
 - **Pectra (May 7, 2025):** EIP-7702 smart EOAs, 2x blob capacity, BLS precompiles
-- **Fusaka (Dec 3, 2025):** PeerDAS (nodes sample 1/8 of data), 2x gas limit (30M→60M)
+- **Fusaka (Dec 3, 2025):** PeerDAS (nodes sample 1/8 of data), gas limit raised to 60M (EIP-7935)
 
 **Agent infrastructure:** You probably don't know these exist:
 - **ERC-8004** — onchain agent identity registry (deployed Jan 29, 2026)


### PR DESCRIPTION
## What's wrong

- **"2x gas limit"** — Fusaka (EIP-7935) raised the L1 gas limit to 60M. But validators had already voted it to ~45M before Fusaka shipped, so the actual on-chain change was ~33%, not 2x. Appeared in `SKILL.md`, `why/SKILL.md`, and `gas/SKILL.md`.
- **ETH price "$2,000 (early/Mar 2026)"** — It's now April 2026 and ETH is ~$2,196. Updated to "~$2,000-2,200 in 2026" in all places.
- **Glamsterdam timing** — Checkpoint #9 (April 10) says Q2 completion "seems unlikely." Added note that it's running behind schedule.
- **Hegotá missing from protocol fork table** — FOCIL (EIP-7805) is confirmed as the consensus headliner for Hegotá, with Account Abstraction (EIP-8141) as non-headliner. Added to `protocol/SKILL.md`.

## Changes

- `SKILL.md` — ETH price range, gas limit claim, Glamsterdam delay note, Hegotá mention
- `why/SKILL.md` — ETH price range, gas limit claim
- `gas/SKILL.md` — ETH price range, gas limit claim
- `protocol/SKILL.md` — Hegotá row in fork table

🤖 Generated with [Claude Code](https://claude.com/claude-code)