### PR TITLE
docs: point sub-skills to addresses/SKILL.md and tighten QA checks

### DIFF
--- a/frontend-playbook/SKILL.md
+++ b/frontend-playbook/SKILL.md
@@ -7,7 +7,7 @@ description: The complete build-to-production pipeline for Ethereum dApps. Fork 
 
 ## What You Probably Got Wrong
 
-**"I'll use `yarn chain`."** Wrong. `yarn chain` gives you an empty local chain with no protocols, no tokens, no state. `yarn fork --network base` gives you a copy of real Base with Uniswap, Aave, USDC, real whale balances — everything. Always fork.
+**"I'll use `yarn chain`."** Wrong. `yarn chain` gives you an empty local chain with no protocols, no tokens, no state. `yarn fork --network base` gives you a copy of real Base with Uniswap, Aave, USDC, real whale balances — everything (verified addresses: `addresses/SKILL.md`). Always fork.
 
 **"I deployed to IPFS and it works."** Did the CID change? If not, you deployed stale output. Did routes work? Without `trailingSlash: true`, every route except `/` returns 404. Did you check the OG image? Without `NEXT_PUBLIC_PRODUCTION_URL`, it points to `localhost:3000`.
 

--- a/orchestration/SKILL.md
+++ b/orchestration/SKILL.md
@@ -30,7 +30,7 @@ yarn fork --network base  # Terminal 1: fork of real chain (or mainnet, your tar
 yarn deploy               # Terminal 2: deploy contracts
 ```
 
-> **Always fork, never `yarn chain`.** `yarn fork` does everything `yarn chain` does AND gives you real protocol state — Uniswap, USDC, Aave, whale balances, everything already deployed. `yarn chain` gives you an empty chain that tempts you into writing mock contracts you don't need. Don't mock what already exists onchain — just fork it.
+> **Always fork, never `yarn chain`.** `yarn fork` does everything `yarn chain` does AND gives you real protocol state — Uniswap, USDC, Aave, whale balances, everything already deployed (verified addresses: `addresses/SKILL.md`). `yarn chain` gives you an empty chain that tempts you into writing mock contracts you don't need. Don't mock what already exists onchain — just fork it.
 
 **Critical steps:**
 1. Write contracts in `packages/foundry/contracts/` (or `packages/hardhat/contracts/`)

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -48,8 +48,18 @@ The app must show exactly ONE primary button at a time, progressing through:
 Check specifically:
 - ❌ **FAIL:** Approve and Action buttons both visible simultaneously
 - ❌ **FAIL:** No network check — app tries to work on wrong chain and fails silently
+- ❌ **FAIL:** Main onchain CTA renders instead of a "Switch to [Chain]" button when the connected wallet is on the wrong network. SE-2's header `WrongNetworkDropdown` is **not sufficient** — the action button itself must become the switch CTA, or the user clicks Sign/Stake/Deposit on the wrong chain and eats a silent wagmi error.
 - ❌ **FAIL:** User can click Approve, sign in wallet, come back, and click Approve again while tx is pending
 - ✅ **PASS:** One button at a time. Approve button shows spinner, stays disabled until block confirms onchain. Then switches to the action button.
+- ✅ **PASS:** Action button's render path branches on `useChainId() === targetNetwork.id` (or equivalent); mismatch renders a `useSwitchChain`-driven "Switch to [Chain]" button in the **same slot** as the primary CTA.
+
+**In the code:** grep the page(s) that own the primary CTA for a chainId check:
+
+```
+grep -rnE "useChainId|useAccount.*chain|targetNetwork\.id" packages/nextjs/app/
+```
+
+If the file with `useScaffoldWriteContract` has no chainId comparison near the button's render branch → FAIL. Header-only network handling does not cover this.
 
 **In the code:** the button's `disabled` prop must be tied to `isPending` from `useScaffoldWriteContract`. Verify it uses `useScaffoldWriteContract` (waits for block confirmation), NOT raw wagmi `useWriteContract` (resolves on wallet signature):
 
@@ -411,7 +421,7 @@ Report each as PASS or FAIL:
 
 ### Ship-Blocking
 - [ ] Wallet connection shows a BUTTON, not text
-- [ ] Wrong network shows a Switch button
+- [ ] Wrong network shows a Switch button **in the primary CTA slot** (not only in the header dropdown)
 - [ ] One button at a time (Connect → Network → Approve → Action)
 - [ ] Approve button locked through full cycle: `approvalSubmitting` (click→hash), `approveCooldown` (confirm→cache refresh) — both states required, both on the `disabled` prop
 - [ ] Contracts verified on block explorer (Etherscan/Basescan/Arbiscan) — source code readable by anyone

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -53,14 +53,6 @@ Check specifically:
 - ✅ **PASS:** One button at a time. Approve button shows spinner, stays disabled until block confirms onchain. Then switches to the action button.
 - ✅ **PASS:** Action button's render path branches on `useChainId() === targetNetwork.id` (or equivalent); mismatch renders a `useSwitchChain`-driven "Switch to [Chain]" button in the **same slot** as the primary CTA.
 
-**In the code:** grep the page(s) that own the primary CTA for a chainId check:
-
-```
-grep -rnE "useChainId|useAccount.*chain|targetNetwork\.id" packages/nextjs/app/
-```
-
-If the file with `useScaffoldWriteContract` has no chainId comparison near the button's render branch → FAIL. Header-only network handling does not cover this.
-
 **In the code:** the button's `disabled` prop must be tied to `isPending` from `useScaffoldWriteContract`. Verify it uses `useScaffoldWriteContract` (waits for block confirmation), NOT raw wagmi `useWriteContract` (resolves on wallet signature):
 
 ```

--- a/security/SKILL.md
+++ b/security/SKILL.md
@@ -144,7 +144,7 @@ function getPrice() internal view returns (uint256) {
 
 **If you must use onchain price data:**
 - Use **TWAP** (Time-Weighted Average Price) over 30+ minutes — resistant to single-block manipulation
-- Uniswap V3 has built-in TWAP oracles via `observe()`
+- Uniswap V3 has built-in TWAP oracles via `observe()` (verified addresses: `addresses/SKILL.md`)
 - Still less safe than Chainlink for high-value decisions
 
 ### 6. Vault Inflation Attack

--- a/testing/SKILL.md
+++ b/testing/SKILL.md
@@ -11,7 +11,7 @@ description: Smart contract testing with Foundry — unit tests, fuzz testing, f
 
 **You don't fuzz.** `forge test` finds the bugs you thought of. Fuzzing finds the ones you didn't. If your contract does math, fuzz it. If it handles user input, fuzz it. If it moves value, definitely fuzz it.
 
-**You don't fork-test.** If your contract calls Uniswap, Aave, or any external protocol, test against their real deployed contracts on a fork. Mocking them hides integration bugs that only appear with real state.
+**You don't fork-test.** If your contract calls Uniswap, Aave, or any external protocol (verified addresses: `addresses/SKILL.md`), test against their real deployed contracts on a fork. Mocking them hides integration bugs that only appear with real state.
 
 **You write tests that mirror the implementation.** Testing that `deposit(100)` sets `balance[user] = 100` is tautological — you're testing that Solidity assignments work. Test properties: "after deposit and withdraw, user gets their tokens back." Test invariants: "total deposits always equals contract balance."
 
@@ -197,7 +197,7 @@ Test your contract against real deployed protocols on a mainnet fork. This catch
 
 ```solidity
 contract SwapTest is Test {
-    // Real mainnet addresses
+    // Real mainnet addresses — full verified list: addresses/SKILL.md
     address constant UNISWAP_ROUTER = 0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45;
     address constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
     address constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;


### PR DESCRIPTION
## Summary

- Point sub-skills that mention Uniswap/Aave addresses to `addresses/SKILL.md` as the authoritative source
- QA: drop prescriptive grep snippet — rule lines carry the check
- QA: mark page-level CTA network check as explicit FAIL

🤖 Generated with [Claude Code](https://claude.com/claude-code)