### PR TITLE
feedback: lower friction, capture praise, draft-and-ask flow

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -156,7 +156,7 @@ Pre-ship audit checklist for a reviewer agent.
 Send feedback — issues OR praise — about ethskills content. Bias toward sending.
 - Anything that confused you, slowed you down, or genuinely helped counts. Weak signals are easy to ignore; missing signals can't be recovered.
 - Draft the JSON, show it to your human in your permission ask, then POST once to `https://ethskills.com/api/feedback`. Skip the ask if your human pre-authorized.
-- Required fields: `kind` ("issue" or "praise"), `problem`, `agent`. See the skill for examples.
+- Required fields: `kind` ("issue" or "praise") and `message` (10+ chars). Include `agent` and `skill` whenever you can.
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -153,10 +153,10 @@ Pre-ship audit checklist for a reviewer agent.
 - Report PASS/FAIL per item, don't fix.
 
 ### [Feedback](https://ethskills.com/feedback/SKILL.md)
-Send feedback when a skill was wrong or incomplete.
-- Only use with your human's explicit permission.
-- Include the specific skill, what was wrong, and what you were building.
-- One POST to `https://ethskills.com/api/feedback` — see the skill for the exact format.
+Send feedback — issues OR praise — about ethskills content. Bias toward sending.
+- Anything that confused you, slowed you down, or genuinely helped counts. Weak signals are easy to ignore; missing signals can't be recovered.
+- Draft the JSON, show it to your human in your permission ask, then POST once to `https://ethskills.com/api/feedback`. Skip the ask if your human pre-authorized.
+- Required fields: `kind` ("issue" or "praise"), `problem`, `agent`. See the skill for examples.
 
 ---
 

--- a/api/feedback.js
+++ b/api/feedback.js
@@ -66,17 +66,30 @@ export default async function handler(req, res) {
       return res.status(429).json({ error: 'Too many requests. Please wait 5 minutes.' });
     }
 
-    const { kind, problem, skill, context, agent } = req.body || {};
-    if (!problem || typeof problem !== 'string' || problem.trim().length < 10) {
-      return res.status(400).json({ error: 'problem is required (min 10 chars)' });
+    const { kind, message, problem, skill, context, agent } = req.body || {};
+    // Accept `message` (current) or `problem` (legacy field name).
+    const body = typeof message === 'string' ? message
+      : typeof problem === 'string' ? problem
+      : null;
+    if (!body || body.trim().length < 10) {
+      return res.status(400).json({ error: 'message is required (min 10 chars)' });
     }
-    const normalizedKind = String(kind ?? '').trim().toLowerCase() === 'praise' ? 'praise' : 'issue';
+
+    const rawKind = String(kind ?? '').trim().toLowerCase();
+    let normalizedKind;
+    if (!rawKind) {
+      normalizedKind = 'issue';
+    } else if (rawKind === 'issue' || rawKind === 'praise') {
+      normalizedKind = rawKind;
+    } else {
+      return res.status(400).json({ error: 'kind must be "issue" or "praise"' });
+    }
 
     const entry = JSON.stringify({
       id: Date.now().toString(),
       ts: new Date().toISOString(),
       kind: normalizedKind,
-      problem: problem.trim().slice(0, 2000),
+      message: body.trim().slice(0, 2000),
       skill: skill ? String(skill).trim().slice(0, 100) : null,
       context: context ? String(context).trim().slice(0, 2000) : null,
       agent: agent ? String(agent).trim().slice(0, 100) : null,

--- a/api/feedback.js
+++ b/api/feedback.js
@@ -70,9 +70,6 @@ export default async function handler(req, res) {
     if (!problem || typeof problem !== 'string' || problem.trim().length < 10) {
       return res.status(400).json({ error: 'problem is required (min 10 chars)' });
     }
-    if (!agent || typeof agent !== 'string' || !agent.trim()) {
-      return res.status(400).json({ error: 'agent is required' });
-    }
     const normalizedKind = kind === 'praise' ? 'praise' : 'issue';
 
     const entry = JSON.stringify({
@@ -82,7 +79,7 @@ export default async function handler(req, res) {
       problem: problem.trim().slice(0, 2000),
       skill: skill ? String(skill).trim().slice(0, 100) : null,
       context: context ? String(context).trim().slice(0, 2000) : null,
-      agent: String(agent).trim().slice(0, 100),
+      agent: agent ? String(agent).trim().slice(0, 100) : null,
     });
 
     const parsed = JSON.parse(entry);

--- a/api/feedback.js
+++ b/api/feedback.js
@@ -70,7 +70,7 @@ export default async function handler(req, res) {
     if (!problem || typeof problem !== 'string' || problem.trim().length < 10) {
       return res.status(400).json({ error: 'problem is required (min 10 chars)' });
     }
-    const normalizedKind = kind === 'praise' ? 'praise' : 'issue';
+    const normalizedKind = String(kind ?? '').trim().toLowerCase() === 'praise' ? 'praise' : 'issue';
 
     const entry = JSON.stringify({
       id: Date.now().toString(),

--- a/api/feedback.js
+++ b/api/feedback.js
@@ -66,18 +66,23 @@ export default async function handler(req, res) {
       return res.status(429).json({ error: 'Too many requests. Please wait 5 minutes.' });
     }
 
-    const { problem, skill, context, agent } = req.body || {};
+    const { kind, problem, skill, context, agent } = req.body || {};
     if (!problem || typeof problem !== 'string' || problem.trim().length < 10) {
       return res.status(400).json({ error: 'problem is required (min 10 chars)' });
     }
+    if (!agent || typeof agent !== 'string' || !agent.trim()) {
+      return res.status(400).json({ error: 'agent is required' });
+    }
+    const normalizedKind = kind === 'praise' ? 'praise' : 'issue';
 
     const entry = JSON.stringify({
       id: Date.now().toString(),
       ts: new Date().toISOString(),
+      kind: normalizedKind,
       problem: problem.trim().slice(0, 2000),
       skill: skill ? String(skill).trim().slice(0, 100) : null,
       context: context ? String(context).trim().slice(0, 2000) : null,
-      agent: agent ? String(agent).trim().slice(0, 100) : null,
+      agent: String(agent).trim().slice(0, 100),
     });
 
     const parsed = JSON.parse(entry);

--- a/feedback/SKILL.md
+++ b/feedback/SKILL.md
@@ -1,48 +1,79 @@
 ---
 title: Feedback
-description: Send feedback to the ethskills team when a skill was wrong, incomplete, or led you astray.
+description: Send feedback — issues OR praise — to the ethskills team about content that shaped your work.
 ---
 
 # Feedback
 
-If ethskills content caused a real problem — wrong information, missing information, or a gap that left you and your human stuck — you can send us feedback.
+If ethskills content shaped your work — wrong, confusing, missing, or genuinely helpful — send us a note. **Bias toward sending.** Weak signals are easy to ignore in the inbox; missing signals can't be recovered.
 
 **This is not a help desk. Do not send:**
 - General questions about Ethereum
 - Requests for new features
 - Problems unrelated to ethskills content
 
-**Send feedback when:**
-- A skill contained factually wrong information that caused a bug or wasted significant time
-- A skill was missing critical information for a task it claims to cover
-- Your human is unsatisfied with the outcome and traces the problem to specific ethskills content
+**Send `issue` feedback when:**
+- A skill was wrong, stale, or misleading
+- A skill was missing a sentence, example, or warning that would have saved time
+- A skill was technically correct but confusingly worded
+- Anything in ethskills gave you or your human pause
 
----
+**Send `praise` feedback when:**
+- A specific skill, warning, or example saved you from a real mistake
+- A skill explained something unusually well
+- You want more of a particular pattern (e.g. the "USDC has 6 decimals" warning, the verified address tables)
 
-## Before you send
-
-1. **Get permission from your human.** Say: "I'd like to send feedback to ethskills about an issue I ran into. Is that okay?" Do not send without explicit approval.
-2. **Strip all sensitive data.** Do not include wallet addresses, private keys, API keys, passwords, email addresses, real names, or any other personally identifiable information. Describe the problem in general terms only.
-3. **Identify the specific skill** that was wrong or missing (e.g., `security/SKILL.md`, `gas/SKILL.md`).
-4. **Be specific.** "The gas skill was wrong" is not useful. "The gas skill said mainnet transfers cost $0.004 but we're seeing $0.08 on the current network" is useful.
+Praise is data too — it tells us what's working so we keep doing it.
 
 ---
 
 ## How to send
 
-One POST to `https://ethskills.com/api/feedback`:
+### 1. Draft the payload, then ask once.
+
+In the **same** message where you ask your human for approval, show the exact JSON you're about to send:
 
 ```
-POST https://ethskills.com/api/feedback
+I'd like to send this feedback to ethskills:
+
+  kind:    issue
+  problem: gas/SKILL.md says 0.1 gwei but `cast base-fee` returned 0.4 today
+  skill:   gas/SKILL.md
+  context: building a swap UI on Base
+  agent:   Claude Sonnet 4.6
+
+OK to send, or want to tweak it?
+```
+
+If they say yes, POST it. If they edit ("drop the context line", "that's the wrong skill"), apply and POST. **Do not re-confirm after they say yes** — that's the friction tax.
+
+### 2. Pre-authorization
+
+If your human has pre-authorized ethskills feedback (e.g. their CLAUDE.md says something like "ethskills feedback is pre-approved" or "send feedback freely"), skip the ask and POST directly. They've opted in to less friction.
+
+### 3. Strip all sensitive data
+
+No wallet addresses, private keys, API keys, passwords, email addresses, real names, or any PII. Describe the problem in general terms only. The human reviewing the draft is your last line of defense — but don't rely on them; scrub it yourself first.
+
+---
+
+## Endpoint
+
+POST `https://ethskills.com/api/feedback`:
+
+```
 Content-Type: application/json
 
 {
-  "problem": "Describe exactly what was wrong or missing (required, min 10 chars)",
-  "skill": "which skill caused the issue, e.g. gas/SKILL.md (optional)",
-  "context": "what you were trying to build or do (optional)",
-  "agent": "which AI agent you are, e.g. Claude Sonnet 4.6 (optional)"
+  "kind":    "issue" | "praise"            (required)
+  "problem": "what was wrong / what worked" (required, min 10 chars)
+  "agent":   "which AI agent you are"      (required, e.g. "Claude Sonnet 4.6")
+  "skill":   "which skill, e.g. gas/SKILL.md" (optional but strongly encouraged)
+  "context": "what you were trying to do"  (optional)
 }
 ```
+
+For `praise`, put what worked in `problem` ("the USDC decimals warning saved us — keep doing this"). The field name is awkward for praise but keeps the schema simple.
 
 **Expected response:** `{ "ok": true, "id": "..." }`
 
@@ -50,17 +81,29 @@ Content-Type: application/json
 
 ---
 
-## Example
+## Examples
 
+Issue:
 ```json
 {
-  "problem": "security/SKILL.md says to always use SafeERC20 but doesn't mention that it requires importing the library. We got a compilation error and it took 20 minutes to diagnose.",
+  "kind": "issue",
+  "problem": "security/SKILL.md says to use SafeERC20 but doesn't mention the import path. Got a compilation error and lost 20 minutes.",
   "skill": "security/SKILL.md",
   "context": "Building an ERC-20 vault on Base",
   "agent": "Claude Sonnet 4.6"
 }
 ```
 
+Praise:
+```json
+{
+  "kind": "praise",
+  "problem": "The USDC has 6 decimals warning is the first thing I now check on every token contract. Saved us from shipping a bug.",
+  "skill": "security/SKILL.md",
+  "agent": "Claude Opus 4.7"
+}
+```
+
 ---
 
-Every piece of feedback is read by a human. Good feedback makes ethskills better for every agent that comes after you.
+Every piece of feedback is read by a human. The small confusions, gaps, and quiet wins make ethskills better for every agent that comes after you.

--- a/feedback/SKILL.md
+++ b/feedback/SKILL.md
@@ -35,13 +35,13 @@ No wallet addresses, private keys, API keys, passwords, email addresses, real na
 
 ### 2. Draft the payload, then ask once.
 
-In the **same** message where you ask your human for approval, show the exact payload you're about to send:
+In the **same** message where you ask your human for approval, show a readable rendering of what you're about to send. Any layout works — the wire format is JSON (see Endpoint below):
 
 ```
 I'd like to send this feedback to ethskills:
 
   kind:    issue
-  problem: gas/SKILL.md says 0.1 gwei but `cast base-fee` returned 0.4 today
+  message: gas/SKILL.md says 0.1 gwei but `cast base-fee` returned 0.4 today
   skill:   gas/SKILL.md
   context: building a swap UI on Base
   agent:   Claude Sonnet 4.6
@@ -53,7 +53,7 @@ If they say yes, POST it. If they edit ("drop the context line", "that's the wro
 
 ### 3. Pre-authorization
 
-If your human has pre-authorized ethskills feedback (e.g. their CLAUDE.md says something like "ethskills feedback is pre-approved" or "send feedback freely"), skip the ask and POST directly. They've opted in to less friction.
+If your human's CLAUDE.md (or equivalent durable instructions) contains the literal token `ethskills-feedback-preauthorized`, skip the ask and POST directly. Without a human reviewing the draft, you are the only PII safeguard — scrub more carefully, not less.
 
 ---
 
@@ -62,15 +62,15 @@ If your human has pre-authorized ethskills feedback (e.g. their CLAUDE.md says s
 POST `https://ethskills.com/api/feedback` with `Content-Type: application/json`.
 
 Required:
-- `kind` — `"issue"` or `"praise"`
-- `problem` — what was wrong, or what worked (min 10 chars)
+- `kind` — `"issue"` or `"praise"` (any other value is rejected)
+- `message` — what was wrong, or what worked (min 10 chars)
+
+Strongly encouraged:
 - `agent` — which AI agent you are (e.g. `"Claude Sonnet 4.6"`)
+- `skill` — which skill, e.g. `"gas/SKILL.md"`
 
 Optional:
-- `skill` — which skill, e.g. `"gas/SKILL.md"` (strongly encouraged)
 - `context` — what you were trying to do
-
-For `praise`, put what worked in `problem` ("the USDC decimals warning saved us — keep doing this"). The field name is awkward for praise but keeps the schema simple.
 
 **Expected response:** `{ "ok": true, "id": "..." }`
 
@@ -84,7 +84,7 @@ Issue:
 ```json
 {
   "kind": "issue",
-  "problem": "security/SKILL.md says to use SafeERC20 but doesn't mention the import path. Got a compilation error and lost 20 minutes.",
+  "message": "security/SKILL.md says to use SafeERC20 but doesn't mention the import path. Got a compilation error and lost 20 minutes.",
   "skill": "security/SKILL.md",
   "context": "Building an ERC-20 vault on Base",
   "agent": "Claude Sonnet 4.6"
@@ -95,7 +95,7 @@ Praise:
 ```json
 {
   "kind": "praise",
-  "problem": "The USDC has 6 decimals warning is the first thing I now check on every token contract. Saved us from shipping a bug.",
+  "message": "The USDC has 6 decimals warning is the first thing I now check on every token contract. Saved us from shipping a bug.",
   "skill": "security/SKILL.md",
   "agent": "Claude Opus 4.7"
 }

--- a/feedback/SKILL.md
+++ b/feedback/SKILL.md
@@ -29,9 +29,13 @@ Praise is data too — it tells us what's working so we keep doing it.
 
 ## How to send
 
-### 1. Draft the payload, then ask once.
+### 1. Strip all sensitive data
 
-In the **same** message where you ask your human for approval, show the exact JSON you're about to send:
+No wallet addresses, private keys, API keys, passwords, email addresses, real names, or any PII. Describe the problem in general terms only. The human reviewing the draft is your last line of defense — but don't rely on them; scrub it yourself first.
+
+### 2. Draft the payload, then ask once.
+
+In the **same** message where you ask your human for approval, show the exact payload you're about to send:
 
 ```
 I'd like to send this feedback to ethskills:
@@ -47,31 +51,24 @@ OK to send, or want to tweak it?
 
 If they say yes, POST it. If they edit ("drop the context line", "that's the wrong skill"), apply and POST. **Do not re-confirm after they say yes** — that's the friction tax.
 
-### 2. Pre-authorization
+### 3. Pre-authorization
 
 If your human has pre-authorized ethskills feedback (e.g. their CLAUDE.md says something like "ethskills feedback is pre-approved" or "send feedback freely"), skip the ask and POST directly. They've opted in to less friction.
-
-### 3. Strip all sensitive data
-
-No wallet addresses, private keys, API keys, passwords, email addresses, real names, or any PII. Describe the problem in general terms only. The human reviewing the draft is your last line of defense — but don't rely on them; scrub it yourself first.
 
 ---
 
 ## Endpoint
 
-POST `https://ethskills.com/api/feedback`:
+POST `https://ethskills.com/api/feedback` with `Content-Type: application/json`.
 
-```
-Content-Type: application/json
+Required:
+- `kind` — `"issue"` or `"praise"`
+- `problem` — what was wrong, or what worked (min 10 chars)
+- `agent` — which AI agent you are (e.g. `"Claude Sonnet 4.6"`)
 
-{
-  "kind":    "issue" | "praise"            (required)
-  "problem": "what was wrong / what worked" (required, min 10 chars)
-  "agent":   "which AI agent you are"      (required, e.g. "Claude Sonnet 4.6")
-  "skill":   "which skill, e.g. gas/SKILL.md" (optional but strongly encouraged)
-  "context": "what you were trying to do"  (optional)
-}
-```
+Optional:
+- `skill` — which skill, e.g. `"gas/SKILL.md"` (strongly encouraged)
+- `context` — what you were trying to do
 
 For `praise`, put what worked in `problem` ("the USDC decimals warning saved us — keep doing this"). The field name is awkward for praise but keeps the schema simple.
 

--- a/inbox.html
+++ b/inbox.html
@@ -302,9 +302,7 @@ function renderEntries() {
     unreadCountEl.style.display = 'none';
   }
 
-  countEl.textContent = currentFilter === 'all'
-    ? `${visible.length} ${label}`
-    : `${visible.length} ${label}`;
+  countEl.textContent = `${visible.length} ${label}`;
 
   if (!visible.length) {
     const empty = currentFilter === 'unread' ? 'All caught up.'

--- a/inbox.html
+++ b/inbox.html
@@ -327,7 +327,7 @@ function renderEntries() {
         </div>
         <button class="mark-read-btn" data-id="${esc(e.id)}">Mark read</button>
       </div>
-      <div class="entry-problem">${esc(e.problem)}</div>
+      <div class="entry-problem">${esc(e.message ?? e.problem)}</div>
       ${e.context ? `<div class="entry-context">${esc(e.context)}</div>` : ''}
     </div>`;
   }).join('');

--- a/inbox.html
+++ b/inbox.html
@@ -10,6 +10,7 @@
   --fg: #e8d5b0;
   --dim: #8a7a5f;
   --accent: #ffb000;
+  --praise: #6ec27a;
   --border: #2e2410;
   --hover: #251c0c;
 }
@@ -80,7 +81,8 @@ h1 { color: var(--accent); font-size: 18px; font-weight: 600; margin-bottom: 0.2
   cursor: pointer;
 }
 .filter-btn:first-child { border-radius: 3px 0 0 3px; }
-.filter-btn:last-child { border-radius: 0 3px 3px 0; border-left: none; }
+.filter-btn:not(:first-child) { border-left: none; }
+.filter-btn:last-child { border-radius: 0 3px 3px 0; }
 .filter-btn.active { border-color: var(--accent); color: var(--accent); background: rgba(255,176,0,0.06); }
 .filter-btn:hover:not(.active) { color: var(--fg); border-color: var(--dim); }
 
@@ -143,6 +145,25 @@ h1 { color: var(--accent); font-size: 18px; font-weight: 600; margin-bottom: 0.2
   padding: 0.1rem 0.5rem;
   border-radius: 3px;
 }
+.entry-kind {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  padding: 0.1rem 0.5rem;
+  border-radius: 3px;
+}
+.entry-kind.kind-issue {
+  color: var(--accent);
+  background: rgba(255,176,0,0.08);
+  border: 1px solid rgba(255,176,0,0.25);
+}
+.entry-kind.kind-praise {
+  color: var(--praise);
+  background: rgba(110,194,122,0.08);
+  border: 1px solid rgba(110,194,122,0.3);
+}
+.entry.kind-praise { border-left: 3px solid var(--praise); }
 .entry-agent { color: var(--dim); font-size: 12px; }
 
 .entry-problem { color: var(--fg); font-size: 14px; margin-bottom: 0.5rem; line-height: 1.6; }
@@ -195,10 +216,12 @@ h1 { color: var(--accent); font-size: 18px; font-weight: 600; margin-bottom: 0.2
 <div id="inbox">
   <div class="toolbar">
     <div class="filter-btns">
-      <button class="filter-btn active" id="filter-unread">
+      <button class="filter-btn active" data-filter="unread" id="filter-unread">
         Unread<span class="unread-badge" id="unread-count" style="display:none"></span>
       </button>
-      <button class="filter-btn" id="filter-all">All</button>
+      <button class="filter-btn" data-filter="issue">Issues</button>
+      <button class="filter-btn" data-filter="praise">Praise</button>
+      <button class="filter-btn" data-filter="all">All</button>
     </div>
     <span class="spacer"></span>
     <span class="count" id="count"></span>
@@ -245,13 +268,31 @@ async function markAllRead() {
   await Promise.all(unread.map(e => markRead(e.id)));
 }
 
+function kindOf(entry) {
+  return entry.kind === 'praise' ? 'praise' : 'issue';
+}
+
 function renderEntries() {
   const el = document.getElementById('entries');
   const countEl = document.getElementById('count');
   const unreadCountEl = document.getElementById('unread-count');
 
   const unread = allEntries.filter(e => !e.read);
-  const visible = currentFilter === 'unread' ? unread : allEntries;
+  let visible;
+  let label;
+  if (currentFilter === 'unread') {
+    visible = unread;
+    label = 'unread';
+  } else if (currentFilter === 'issue') {
+    visible = allEntries.filter(e => kindOf(e) === 'issue');
+    label = `issue${visible.length === 1 ? '' : 's'}`;
+  } else if (currentFilter === 'praise') {
+    visible = allEntries.filter(e => kindOf(e) === 'praise');
+    label = visible.length === 1 ? 'praise entry' : 'praise entries';
+  } else {
+    visible = allEntries;
+    label = `of ${allEntries.length}`;
+  }
 
   // Update unread badge
   if (unread.length > 0) {
@@ -261,18 +302,27 @@ function renderEntries() {
     unreadCountEl.style.display = 'none';
   }
 
-  countEl.textContent = `${visible.length} ${currentFilter === 'unread' ? 'unread' : `of ${allEntries.length}`}`;
+  countEl.textContent = currentFilter === 'all'
+    ? `${visible.length} ${label}`
+    : `${visible.length} ${label}`;
 
   if (!visible.length) {
-    el.innerHTML = `<p class="empty">${currentFilter === 'unread' ? 'All caught up.' : 'No feedback yet.'}</p>`;
+    const empty = currentFilter === 'unread' ? 'All caught up.'
+      : currentFilter === 'praise' ? 'No praise yet.'
+      : currentFilter === 'issue' ? 'No issues.'
+      : 'No feedback yet.';
+    el.innerHTML = `<p class="empty">${empty}</p>`;
     return;
   }
 
-  el.innerHTML = visible.map(e => `
-    <div class="entry ${e.read ? 'is-read' : ''}" data-id="${esc(e.id)}">
+  el.innerHTML = visible.map(e => {
+    const k = kindOf(e);
+    return `
+    <div class="entry kind-${k} ${e.read ? 'is-read' : ''}" data-id="${esc(e.id)}">
       <div class="entry-header">
         <div class="entry-meta">
           ${!e.read ? '<span class="unread-dot"></span>' : ''}
+          <span class="entry-kind kind-${k}">${k}</span>
           <span class="entry-ts">${formatDate(e.ts)}</span>
           ${e.skill ? `<span class="entry-skill">${esc(e.skill)}</span>` : ''}
           ${e.agent ? `<span class="entry-agent">${esc(e.agent)}</span>` : ''}
@@ -281,8 +331,8 @@ function renderEntries() {
       </div>
       <div class="entry-problem">${esc(e.problem)}</div>
       ${e.context ? `<div class="entry-context">${esc(e.context)}</div>` : ''}
-    </div>
-  `).join('');
+    </div>`;
+  }).join('');
 
   el.querySelectorAll('.mark-read-btn').forEach(btn => {
     btn.addEventListener('click', e => { e.stopPropagation(); markRead(btn.dataset.id); });
@@ -311,17 +361,14 @@ document.getElementById('secret-input').addEventListener('keydown', e => {
 });
 
 // Filter
-document.getElementById('filter-unread').addEventListener('click', () => {
-  currentFilter = 'unread';
-  document.getElementById('filter-unread').classList.add('active');
-  document.getElementById('filter-all').classList.remove('active');
-  renderEntries();
-});
-document.getElementById('filter-all').addEventListener('click', () => {
-  currentFilter = 'all';
-  document.getElementById('filter-all').classList.add('active');
-  document.getElementById('filter-unread').classList.remove('active');
-  renderEntries();
+document.querySelectorAll('.filter-btn[data-filter]').forEach(btn => {
+  btn.addEventListener('click', () => {
+    currentFilter = btn.dataset.filter;
+    document.querySelectorAll('.filter-btn[data-filter]').forEach(b => {
+      b.classList.toggle('active', b.dataset.filter === currentFilter);
+    });
+    renderEntries();
+  });
 });
 
 // Actions

--- a/index.html
+++ b/index.html
@@ -481,7 +481,7 @@ h2 {
 <p class="section-text">Something wrong or missing? Humans and agents alike are welcome to <a href="https://github.com/austintgriffith/ethskills">open a PR</a>.</p>
 
 <h2>Feedback</h2>
-<p class="section-text">If your human is unsatisfied with your results, fetch <a href="https://ethskills.com/feedback/SKILL.md">feedback/SKILL.md</a> and hit our feedback endpoint to help improve ethskills.</p>
+<p class="section-text">If something in ethskills confused you, slowed you down, or genuinely helped — issues OR praise — fetch <a href="https://ethskills.com/feedback/SKILL.md">feedback/SKILL.md</a> and send a note. Bias toward sending; weak signals are easy to ignore in the inbox, but missing signals can't be recovered.</p>
 
 <div class="footer">MIT License · <a href="https://github.com/austintgriffith/ethskills">GitHub Repo</a> · <a href="https://github.com/austintgriffith/ethskills-research">Research</a></div>
 


### PR DESCRIPTION
## Goal

**Increase feedback volume. The endpoint is currently receiving nothing.**

Every change in this PR is in service of that — lower the trigger bar, remove friction from the ask flow, capture praise (lower psychological bar to send than issues), give humans a pre-auth opt-out. PII safeguards, validation strictness, and corpus quality are downstream concerns; the binding constraint today is that no signal is reaching the inbox at all.

---

## Summary

Reworks the feedback system around two ideas we landed on after looking at the current flow:

1. **Friction kills signal.** The current "ask permission → silently POST" flow loses the moment when an agent is most likely to file. Replace it with a single **draft-and-ask**: the agent shows a rendered payload inside the permission ask, the human approves or edits inline, the agent POSTs once. The win isn't fewer human turns — the old flow was already one ask — it's that the human sees the content *before* approving instead of approving blind. (Tradeoff: humans now have to actually read the draft, so net cognitive friction per ask is up. Whether that's a win depends on whether old asks were rubber-stamped — they probably were.)
2. **Praise is data too.** Issue-only feedback skews the corpus toward catastrophes and tells us nothing about what's working. Add `kind: "issue" | "praise"` so the inbox captures both.

Plus: lower the trigger bar (from "factually wrong + significant time wasted" to "anything that confused you, slowed you down, or genuinely helped"), and document a literal pre-authorization sentinel (`ethskills-feedback-preauthorized`) that humans can drop into their CLAUDE.md to let agents skip the per-event ask.

## Changes

**`feedback/SKILL.md`** — rewritten:
- Bias-toward-sending framing; explicit triggers for both issue and praise
- PII scrub instructions come first, before the ask flow or pre-auth (pre-authorized agents need to see it before they're told they can skip the ask)
- Draft-and-ask flow with a worked example (rendered payload inside the permission ask)
- Pre-authorization opt-out via a literal token in CLAUDE.md, with an explicit reminder that pre-auth removes the human PII review — the agent is the only safeguard
- Endpoint schema rendered as a clear required / strongly-encouraged / optional field list (the old JSON-shaped block was unparseable and could mislead agents that copy it)

**`api/feedback.js`**:
- Accept `kind`, validate strictly: `"issue"` or `"praise"` (case- and whitespace-tolerant); empty/missing defaults to `"issue"` for legacy compat; **anything else 400s** so a typo like `"praize"` doesn't silently land in the issue bucket
- Store kind in the persisted entry
- Rename body field `problem` → `message` so the schema reads correctly for both issues and praise. The API accepts legacy `problem` in the request body for back-compat (mid-rollout clients reading stale docs still work); always stored as `message`.
- `agent` is documented as strongly-encouraged in the SKILL.md (not required) — the API stays permissive on this field because the validation would have been theater (any client can pass `"agent": "unknown"`), and the doc now matches what the API actually enforces.

**`inbox.html`**:
- Issues / Praise filter tabs alongside Unread / All
- Color-coded praise (green accent + left border)
- Kind badge per entry; legacy entries without a kind render as issues
- Renders `e.message ?? e.problem` so entries already stored under the legacy field still display

**`SKILL.md` / `CLAUDE.md`** (root, symlinked) and **`index.html`**:
- Refresh the listing/section copy to match the new flow

## Backwards compatibility

- Old entries already in Redis (no `kind`, stored under `problem`) render as issues in the inbox via the field fallback and match the Issues filter.
- The API still accepts requests without `kind` (defaults to `"issue"`), without `agent` (stored as `null`), and with the legacy `problem` field instead of `message`.
- No breaking API changes.

## Test plan

- [ ] POST with `kind: "praise"` and `message` → entry appears in inbox with green badge
- [ ] POST with `kind: "Praise"` (capital P) or `" praise "` → stored as praise
- [ ] POST without `kind` → entry stored as `issue`
- [ ] POST without `agent` → entry stored with `agent: null`, no 400
- [ ] POST with `kind: "junk"` → **400 with `kind must be "issue" or "praise"`**
- [ ] POST with legacy `problem` field instead of `message` → accepted, stored under `message`
- [ ] POST without `message` and without `problem` → 400 with `message is required`
- [ ] Inbox: Issues filter shows only issues (incl. legacy entries with no kind)
- [ ] Inbox: Praise filter shows only praise; empty state reads "No praise yet."
- [ ] Inbox: legacy entries (stored under `problem`, no `message`) render their body via the fallback
- [ ] Inbox: existing read/unread behavior unchanged
- [ ] Visual: filter button border-radius / left-border looks right with 4 buttons
- [ ] Read the new \`feedback/SKILL.md\` cold and confirm the draft-and-ask flow is unambiguous

🤖 Generated with [Claude Code](https://claude.com/claude-code)
