### PR TITLE
fix: improve bot-parsability of HTML page and SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -175,3 +175,7 @@ Send feedback — issues OR praise — about ethskills content. Bias toward send
 | Monitoring / analytics | `indexing/` |
 | Building AI agent infra | `standards/`, `wallets/`, `tools/` |
 | Choosing a chain | `l2s/`, `gas/` |
+
+---
+
+<!-- END ETHSKILLS -->

--- a/index.html
+++ b/index.html
@@ -14,6 +14,9 @@
 <link rel="icon" type="image/svg+xml" href="favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
 <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
+<link rel="alternate" type="text/markdown" href="/SKILL.md" title="ETHSKILLS — full skill index (machine-readable)">
+<link rel="alternate" type="text/plain" href="/llms.txt" title="ETHSKILLS — llms.txt (machine-readable)">
+<meta name="ai-skills" content="https://ethskills.com/SKILL.md">
 <!-- Privacy-friendly analytics by Plausible -->
 <script async src="https://plausible.io/js/pa-OJ2HwbywhcpZ1FyxkBxzG.js"></script>
 <script>
@@ -287,36 +290,31 @@ h2 {
 </head>
 <body>
 
-<!--
-  ETHSKILLS — Ethereum Knowledge for AI Agents
-  https://ethskills.com
-
-  Bot-readable. Each skill lives at /<topic>/SKILL.md
-  Fetch any URL and read it into your context.
-
-  All skills:  https://ethskills.com/SKILL.md
-
-  Individual skills:
-    https://ethskills.com/ship/SKILL.md              — Ship (start here)
-    https://ethskills.com/why/SKILL.md               — Why Ethereum
-    https://ethskills.com/gas/SKILL.md               — Gas & Costs
-    https://ethskills.com/wallets/SKILL.md           — Wallets
-    https://ethskills.com/l2s/SKILL.md               — Layer 2s
-    https://ethskills.com/standards/SKILL.md         — Standards
-    https://ethskills.com/tools/SKILL.md             — Tools
-    https://ethskills.com/building-blocks/SKILL.md   — Money Legos (DeFi)
-    https://ethskills.com/orchestration/SKILL.md     — Orchestration
-    https://ethskills.com/addresses/SKILL.md         — Contract Addresses
-    https://ethskills.com/concepts/SKILL.md          — Concepts
-    https://ethskills.com/security/SKILL.md          — Security
-    https://ethskills.com/noir/SKILL.md              — Noir (ZK Privacy)
-    https://ethskills.com/testing/SKILL.md           — Testing
-    https://ethskills.com/indexing/SKILL.md          — Indexing
-    https://ethskills.com/frontend-ux/SKILL.md       — Frontend UX
-    https://ethskills.com/frontend-playbook/SKILL.md — Frontend Playbook
-    https://ethskills.com/qa/SKILL.md               — QA (Pre-Ship Audit)
-    https://ethskills.com/audit/SKILL.md            — Audit (Smart Contract Security Audit)
--->
+<!-- Bot-readable skill index: https://ethskills.com/SKILL.md -->
+<div aria-hidden="true" style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;">
+ETHSKILLS — Ethereum Knowledge for AI Agents. Bot-readable. Each skill lives at /topic/SKILL.md — fetch any URL and read it into your context.
+All skills: https://ethskills.com/SKILL.md
+Individual skills:
+https://ethskills.com/ship/SKILL.md — Ship (start here)
+https://ethskills.com/why/SKILL.md — Why Ethereum
+https://ethskills.com/gas/SKILL.md — Gas &amp; Costs
+https://ethskills.com/wallets/SKILL.md — Wallets
+https://ethskills.com/l2s/SKILL.md — Layer 2s
+https://ethskills.com/standards/SKILL.md — Standards
+https://ethskills.com/tools/SKILL.md — Tools
+https://ethskills.com/building-blocks/SKILL.md — Money Legos (DeFi)
+https://ethskills.com/orchestration/SKILL.md — Orchestration
+https://ethskills.com/addresses/SKILL.md — Contract Addresses
+https://ethskills.com/concepts/SKILL.md — Concepts
+https://ethskills.com/security/SKILL.md — Security
+https://ethskills.com/noir/SKILL.md — Noir (ZK Privacy)
+https://ethskills.com/testing/SKILL.md — Testing
+https://ethskills.com/indexing/SKILL.md — Indexing
+https://ethskills.com/frontend-ux/SKILL.md — Frontend UX
+https://ethskills.com/frontend-playbook/SKILL.md — Frontend Playbook
+https://ethskills.com/qa/SKILL.md — QA (Pre-Ship Audit)
+https://ethskills.com/audit/SKILL.md — Audit (Smart Contract Security Audit)
+</div>
 
 <div class="ascii" style="font-size:clamp(0.3rem,calc((100vw - 3rem) / 52),1rem);">
  ███████╗████████╗██╗  ██╗███████╗██╗  ██╗██╗██╗     ██╗     ███████╗


### PR DESCRIPTION
## What

Two small fixes from a bot-eye-view audit of ethskills.com:

### 1. HTML comment → visually-hidden `<div>`

The skill directory was buried in an HTML comment. Text extractors (readability, etc.) can't read HTML comments — and the ones that try leak a stray `-->` artifact into parsed content. Replaced with a visually-hidden `<div aria-hidden="true">` using CSS clip: invisible to humans, parseable by bots.

Also added to `<head>`:
- `<link rel="alternate" type="text/markdown" href="/SKILL.md">`
- `<link rel="alternate" type="text/plain" href="/llms.txt">`
- `<meta name="ai-skills" content="https://ethskills.com/SKILL.md">`

These let crawlers and bots discover the machine-readable entry points without having to parse the full HTML page.

### 2. END marker in SKILL.md

`/SKILL.md` is ~9.2KB. Bots with tight fetch limits get a clean-looking truncation with no signal the file is incomplete. Added `<!-- END ETHSKILLS -->` at the bottom so any agent can verify it received the full file.

## Why

Both issues surfaced by actually fetching the site as a bot and noting where the experience was clunky. The `/SKILL.md` route is already excellent — this just makes the HTML page equally clean.