### PR TITLE
ship,concepts: add CROPS Gate aligned to EF Mandate

### DIFF
--- a/concepts/SKILL.md
+++ b/concepts/SKILL.md
@@ -19,10 +19,10 @@ description: The essential mental models for building onchain — focused on wha
 
 ## CROPS
 
-**CROPS** — Censorship Resistance, Open Source, Privacy, Security — is the Ethereum Foundation's shorthand for what makes Ethereum Ethereum.
+**CROPS** — Censorship Resistance, Open Source and Free, Privacy, Security — is the Ethereum Foundation's shorthand for what makes Ethereum Ethereum.
 
 - **Censorship Resistance** — You scaffold `Pausable` + `onlyOwner` without flagging it. A single key that can freeze all users is a censorship vector.
-- **Open Source** — You treat Etherscan verification as "open source." Real open source means someone can fork the full stack (frontend, indexer, contracts) and run it independently.
+- **Open Source and Free** — You treat Etherscan verification as "open source." Real openness means the full stack is inspectable, forkable, self-hostable, and free enough that users and builders can exit without asking permission.
 - **Privacy** — You build apps where every address, amount, and counterparty is publicly visible on a block explorer and never mention it. At minimum, tell the builder what's exposed.
 - **Security** — You say "audited" and treat it as proof of security. An audit is a point-in-time review of a specific scope, not an ongoing guarantee.
 

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -36,7 +36,11 @@ Answer each with the concrete decision and tradeoff for this app:
 - **Privacy:** what addresses, balances, counterparties, behavior, metadata, or identity data leaks, is that disclosure necessary, and can users selectively negotiate it?
 - **Security:** who controls funds, approvals, upgrades, admin keys, recovery, emergency powers, and the user's exit path? Does the design pass the walkaway test if the team or a critical vendor disappears?
 
-Your output should name the chosen default, the compromises you accept, and the user's escape path. Fetch `concepts/SKILL.md` for the deeper CROPS and incentive mental model.
+Your output should name the chosen default, the compromises you accept, and the user's escape path.
+
+Whenever you present the builder with architecture, custody, infra, permissions, emergency-powers, or other tradeoff options, label each option with its CROPS impact (which properties it strengthens, which it weakens) and call out the most CROPS-aligned choice as the recommended default. Do not present options as a neutral list, builders should see the values cost of each.
+
+Fetch `concepts/SKILL.md` for the deeper CROPS and incentive mental model.
 
 ### The Onchain Litmus Test
 

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -15,6 +15,8 @@ description: End-to-end guide for AI agents — from a dApp idea to deployed pro
 
 **You skip chain selection.** Mainnet is cheaper than you think — an ETH transfer costs ~$0.004, a swap ~$0.04. The "Ethereum is expensive" narrative is outdated. But that doesn't mean everything belongs on mainnet. L2s aren't just "cheaper Ethereum" — each one has a unique superpower (Base has Coinbase distribution + smart wallets, Arbitrum has the deepest DeFi liquidity, Optimism has retroPGF + the Superchain). If your app needs high-frequency interactions or fits what makes an L2 special, build there. If you just need cheap and secure, mainnet works. Choose deliberately. Fetch `l2s/SKILL.md` and `gas/SKILL.md` for the full picture. Not sure Ethereum is the right chain at all? Fetch `why/SKILL.md`.
 
+**You optimize for "works" and skip self-sovereignty.** A dApp can compile, pass tests, and still hand users to a censorable frontend, a closed indexer, an invisible RPC dependency, a custodial wallet, or an admin key with total control. Before coding, check whether the design preserves Ethereum's CROPS properties: Censorship Resistance, Open Source and Free, Privacy, and Security.
+
 **You forget nothing is automatic.** Smart contracts don't run themselves. Every state transition needs a caller who pays gas and a reason to do it. If you can't answer "who calls this and why?" for every function, your contract has dead code. Fetch `concepts/SKILL.md` for the full mental model.
 
 ---
@@ -22,6 +24,19 @@ description: End-to-end guide for AI agents — from a dApp idea to deployed pro
 ## Phase 0 — Plan the Architecture
 
 Do this BEFORE writing any code. Every hour spent here saves ten hours of rewrites.
+
+### CROPS Gate
+
+Before choosing the architecture, run a CROPS check. CROPS means Censorship Resistance, Open Source and Free, Privacy, and Security. It is not a slogan. It is how you avoid shipping an app that works by normalizing capture, hidden trust, or user lock-in.
+
+Answer each with the concrete decision and tradeoff for this app:
+
+- **Censorship Resistance:** who can block valid users, transactions, relayers, RPC access, sequencers, bridges, frontends, or app access, including by gaining durable, non-competitive control of any critical mechanism?
+- **Open Source and Free:** is everything public, auditable, and forkable? Can users or other builders inspect, fork, self-host, integrate, and route around privileged infrastructure?
+- **Privacy:** what addresses, balances, counterparties, behavior, metadata, or identity data leaks, is that disclosure necessary, and can users selectively negotiate it?
+- **Security:** who controls funds, approvals, upgrades, admin keys, recovery, emergency powers, and the user's exit path? Does the design pass the walkaway test if the team or a critical vendor disappears?
+
+Your output should name the chosen default, the compromises you accept, and the user's escape path. Fetch `concepts/SKILL.md` for the deeper CROPS and incentive mental model.
 
 ### The Onchain Litmus Test
 
@@ -283,6 +298,7 @@ Fetch `frontend-playbook/SKILL.md` for the full pipeline:
 
 ## Quick-Start Checklist
 
+- [ ] Run the CROPS Gate before finalizing architecture (censorship, openness, privacy, security)
 - [ ] Identify what goes onchain vs offchain (use the Litmus Test above)
 - [ ] Count your contracts (aim for 1-2 for MVP)
 - [ ] Pick your chain (mainnet is cheap now — pick an L2 only if its superpower fits your app)
@@ -303,7 +319,7 @@ Use this to know which skills to fetch at each phase:
 
 | Phase | What you're doing | Skills to fetch |
 |-------|-------------------|-----------------|
-| **Plan** | Architecture, chain selection | `ship/` (this), `concepts/`, `l2s/`, `gas/`, `why/` |
+| **Plan** | CROPS gate, architecture, chain selection | `ship/` (this), `concepts/`, `l2s/`, `gas/`, `why/` |
 | **Contracts** | Writing Solidity | `standards/`, `building-blocks/`, `addresses/`, `security/` |
 | **Test** | Testing contracts | `testing/` |
 | **Audit** | Security review (fresh agent) | `audit/` |


### PR DESCRIPTION
## Motivation

AI agents routinely ship dApps that compile, test, and demo cleanly while quietly handing users to a censorable frontend, a closed indexer, an invisible RPC dependency, a custodial wallet, or an admin key with total control. The skill catches stale gas claims and decimals bugs, but values-level failures slip through because there is no explicit values gate before architecture.

This PR adds one, anchored to the canonical [EF Mandate](https://blog.ethereum.org/) (which defines CROPS as exactly four properties: Censorship Resistance, Open Source and Free, Privacy, Security).

## What changes

### `ship/SKILL.md`

- Adds a 'self-sovereignty' bullet to **What You Probably Got Wrong**.
- Adds a **Phase 0 CROPS Gate** with one question per CROPS property, using the mandate's own language: durable non-competitive control of critical mechanisms, public/auditable/forkable, selectively negotiate disclosures, the walkaway test if the team or a critical vendor disappears.
- Prompts the agent to answer each with the concrete decision and tradeoff for **this** app, not just list bullets back.
- Requires CROPS-labeled options whenever the agent surfaces a tradeoff later in the planning conversation (custody, infra, permissions, emergency powers, etc.). Each option must show which CROPS letters it strengthens and weakens, and the most CROPS-aligned choice must be marked as the recommended default. Without this, the gate runs once in Phase 0 and then the agent reverts to neutral option lists when builders are actually committing to defaults.
- Adds CROPS Gate to the Quick-Start Checklist and Skill Routing Table.

### `concepts/SKILL.md`

- Updates the CROPS expansion: "Open Source" → "Open Source and Free" to match the mandate.
- Tightens the Open Source corrective failure to cover full-stack inspectability, forkability, self-hosting, and permissionless exit (not only Etherscan verification).

## Relation to existing CROPS work

There are several upstream branches already exploring CROPS (`crops-concepts`, `crops-minimal`, `crops-routing`). The CROPS section already on `master` in `concepts/SKILL.md` was the starting point for this PR. What this branch adds on top:

1. **Mandate-language alignment.** The CROPS labels, questions, and Security/walkaway phrasing track the EF Mandate verbatim, so the skill is traceable to a canonical source.
2. **CROPS-labeled options.** The skill now explicitly tells the agent how to present tradeoffs throughout planning, not only during the gate itself. This is the change that actually shows up in the builder's session, every time options are offered.
3. **Quick-Start Checklist + Skill Routing Table updates** so the gate is discoverable from the existing scan-points.

Happy to split, reshape, or rebase onto any of the in-flight CROPS branches if that lands better.

## Testing

Ran the worked example from the v2 plan ("users let an AI assistant pay their contractors on the 1st of every month") in a fresh agent session with the branch loaded. The gate produced concrete per-property decisions and surfaced labeled emergency-power options with a recommended default, instead of a neutral list. Same prompt without the skill produced `Pausable` + `onlyOwner` and moved on, which is the failure mode `concepts/SKILL.md` flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)