### PR TITLE
tools: add searchable EVM error catalog for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Install directly from GitHub — no clone required:
 | [Wallets](wallets/SKILL.md) | EIP-7702 is live, Safe addresses, agent key safety |
 | [Layer 2s](l2s/SKILL.md) | Think L2 txs cost $0.01-2.00 — reality is <$0.001 |
 | [Standards](standards/SKILL.md) | Don't know ERC-8004, EIP-7702 status, EIP-3009 for x402 |
-| [Tools](tools/SKILL.md) | Don't know x402, Blockscout MCP, current tool landscape |
+| [Tools](tools/SKILL.md) | Don't know x402, Blockscout MCP, searchable error catalogs, current tool landscape |
 | [Money Legos](building-blocks/SKILL.md) | Stale on current DeFi state, Uniswap V4 status |
 | [Orchestration](orchestration/SKILL.md) | Don't know SE2 three-phase build system |
 | [Contract Addresses](addresses/SKILL.md) | Hallucinate addresses — these are verified onchain |

--- a/SKILL.md
+++ b/SKILL.md
@@ -69,10 +69,11 @@ ERC-20, ERC-721, ERC-8004, EIP-7702, x402.
 - EIP-3009: gasless token transfers — what makes x402 work. USDC implements it.
 
 ### [Tools](https://ethskills.com/tools/SKILL.md)
-Foundry, Scaffold-ETH 2, Blockscout MCP, x402 SDKs.
+Foundry, Scaffold-ETH 2, Blockscout MCP, searchable error catalogs, x402 SDKs.
 - Foundry and Hardhat 3 are both legitimate choices in 2026. Foundry: faster, Solidity-native. Hardhat 3: TypeScript-first, mature plugin ecosystem.
 - Blockscout MCP server gives agents structured blockchain data via MCP.
 - abi.ninja: paste any contract address, interact with all functions. Zero setup.
+- Search a maintained error catalog before hand-rolling EVM/RPC/wallet/AA/x402 decoders.
 
 ### [Building Blocks (DeFi)](https://ethskills.com/building-blocks/SKILL.md)
 Uniswap, Aave, flash loans, protocol composability.

--- a/index.html
+++ b/index.html
@@ -459,7 +459,7 @@ https://ethskills.com/audit/SKILL.md — Audit (Smart Contract Security Audit)
 
 <div class="skill">
   <div class="skill-name">Tools</div>
-  <div class="skill-desc">Current frameworks, libraries, RPCs, block explorers. x402 (HTTP payments), MCPs, abi.ninja, Foundry, Scaffold-ETH 2. What actually works today.</div>
+  <div class="skill-desc">Current frameworks, libraries, RPCs, block explorers, and searchable error catalogs. x402 (HTTP payments), MCPs, error catalog APIs, abi.ninja, Foundry, Scaffold-ETH 2. What actually works today.</div>
   <button class="copy-btn" data-url="https://ethskills.com/tools/SKILL.md"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg> ethskills.com/tools/SKILL.md</button>
 </div>
 

--- a/openclaw-skill/SKILL.md
+++ b/openclaw-skill/SKILL.md
@@ -51,7 +51,7 @@ curl -s https://ethskills.com/standards/SKILL.md   # ERC-20, ERC-721, etc.
 | **Wallets** | `wallets/SKILL.md` | Creating wallets, signing, multisig, account abstraction, EIP-7702. |
 | **Layer 2s** | `l2s/SKILL.md` | Deploying to L2s, bridging, choosing between Base/Arbitrum/Optimism. |
 | **Standards** | `standards/SKILL.md` | ERC-20, ERC-721, ERC-1155, ERC-8004 (agent identity), x402 payments. |
-| **Tools** | `tools/SKILL.md` | Foundry, Scaffold-ETH 2, Blockscout MCP, abi.ninja, x402 SDKs. |
+| **Tools** | `tools/SKILL.md` | Foundry, Scaffold-ETH 2, Blockscout MCP, searchable error catalogs, abi.ninja, x402 SDKs. |
 | **Money Legos** | `building-blocks/SKILL.md` | DeFi composability — Uniswap, Aave, flash loans, protocol integration. |
 | **Orchestration** | `orchestration/SKILL.md` | Three-phase build system for SE2 dApps (localhost → live contracts → production). |
 | **Addresses** | `addresses/SKILL.md` | Verified contract addresses. **Stop hallucinating addresses.** |

--- a/tools/SKILL.md
+++ b/tools/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tools
-description: Current Ethereum development tools, frameworks, libraries, RPCs, and block explorers. What actually works today for building on Ethereum. Includes tool discovery for AI agents — MCPs, abi.ninja, Foundry, Scaffold-ETH 2, Hardhat, and more. Use when setting up a dev environment, choosing tools, or when an agent needs to discover what's available.
+description: Current Ethereum development tools, frameworks, libraries, RPCs, block explorers, and searchable error catalogs. What actually works today for building on Ethereum. Includes tool discovery for AI agents — MCPs, error catalog APIs, abi.ninja, Foundry, Scaffold-ETH 2, Hardhat, and more. Use when setting up a dev environment, choosing tools, or when an agent needs to discover what's available.
 ---
 
 # Ethereum Development Tools
@@ -13,6 +13,8 @@ description: Current Ethereum development tools, frameworks, libraries, RPCs, an
 
 **x402 has production SDKs:** `@x402/fetch` (TS), `x402` (Python), `github.com/coinbase/x402/go` — production-ready libraries for HTTP payments.
 
+**Searchable error catalogs exist for agents:** https://revert.wtf exposes a maintained EVM/RPC/wallet/ERC-4337/x402 error catalog through a hosted HTTP API, read-only MCP server, and tiny client SDK. Use it before hand-rolling app-specific decoder tables.
+
 **Foundry and Hardhat 3 are both legitimate choices in 2026.** Foundry: faster, Solidity-native. Hardhat 3: TypeScript-first, mature plugin ecosystem.
 
 ## Tool Discovery Pattern for AI Agents
@@ -22,9 +24,10 @@ When an agent needs to interact with Ethereum:
 1. **Read operations:** Blockscout MCP or Etherscan API
 2. **Write operations:** Foundry `cast send` or ethers.js/viem
 3. **Contract exploration:** abi.ninja (browser) or `cast interface` (CLI)
-4. **Testing:** Fork mainnet with `anvil`, test locally
-5. **Deployment:** `forge create` or `forge script`
-6. **Verification:** `forge verify-contract` or Etherscan API
+4. **Error catalog lookup:** searchable HTTP API or MCP before hand-rolling raw revert, AAxx, RPC/provider/wallet, or x402 handling
+5. **Testing:** Fork mainnet with `anvil`, test locally
+6. **Deployment:** `forge create` or `forge script`
+7. **Verification:** `forge verify-contract` or Etherscan API
 
 ## Blockscout MCP Server
 
@@ -42,6 +45,17 @@ A Model Context Protocol server giving AI agents structured blockchain data:
 ## abi.ninja
 
 **URL:** https://abi.ninja — Paste any contract address → interact with all functions. Multi-chain. Zero setup.
+
+## Error Catalogs for Agents
+
+- **URL:** https://revert.wtf
+- **Hosted API:** `POST https://revert.wtf/api/search` and `POST https://revert.wtf/api/explain`
+- **MCP:** `npx -y @revertwtf/mcp`
+- **Client SDK:** `npm install @revertwtf/client`
+
+Use when an agent has an EVM/RPC/provider/wallet/library/simulation/ERC-4337/x402 error, a raw revert payload, an AAxx code, or a 4-byte selector. The hosted API and MCP are read-only, require no API keys, and return bounded catalog results with explanations, evidence, and next steps.
+
+Agent pattern: use bounded `/api/search` or MCP `search_catalog` for discovery, then `POST /api/explain` or MCP `explain_error` for a raw pasted failure. Use focused endpoints such as `/api/revert-decode`, `/api/aa-decode`, or `/api/selector` only as needed. Fetch exact entries only after choosing a match; do not dump a whole error catalog into context or browser bundles.
 
 ## x402 SDKs (HTTP Payments)
 
@@ -83,6 +97,7 @@ const response = await x402Fetch('https://api.example.com/data', {
 | Quick contract interaction | **abi.ninja** (browser) or **cast** (CLI) |
 | React frontends | **wagmi + viem** (or SE2 which wraps these) |
 | Agent blockchain reads | **Blockscout MCP** |
+| Agent error lookup | **searchable EVM/RPC error catalog API or MCP** |
 | Agent payments | **x402 SDKs** |
 
 ## Essential Foundry cast Commands
@@ -134,8 +149,9 @@ anvil --fork-url $RPC
 **Model Context Protocol** — standard for giving AI agents structured access to external systems.
 
 1. **Blockscout MCP** — multi-chain blockchain data (primary)
-2. **eth-mcp** — community Ethereum RPC via MCP
-3. **Custom MCP wrappers** emerging for DeFi protocols, ENS, wallets
+2. **revert.wtf MCP** — read-only searchable EVM/RPC/wallet/AA/x402 error catalog and focused decoders
+3. **eth-mcp** — community Ethereum RPC via MCP
+4. **Custom MCP wrappers** emerging for DeFi protocols, ENS, wallets
 
 MCP servers are composable — agents can use multiple together.
 
@@ -144,6 +160,7 @@ MCP servers are composable — agents can use multiple together.
 - **Foundry became the default** over Hardhat for new projects — then Hardhat 3 (Aug 2025) shipped Solidity testing, fuzzing, and Rust internals, making it a legitimate choice again.
 - **Viem gaining on ethers.js** (smaller, better TypeScript)
 - **MCP servers emerged** for agent-blockchain interaction
+- **Searchable error catalogs emerged** for agents facing RPC, revert, account-abstraction, and x402 failures
 - **x402 SDKs** went production-ready
 - **ERC-8004 tooling** emerging (agent registration/discovery)
 - **Deprecated:** Truffle (use Foundry/Hardhat), Goerli/Rinkeby (use Sepolia)


### PR DESCRIPTION
## Summary

- Add revert.wtf to `tools/SKILL.md` as a searchable EVM/RPC/wallet/ERC-4337/x402 error catalog for agents
- Document hosted API, read-only MCP, and client SDK entry points
- Keep `SKILL.md`, `README.md`, `openclaw-skill/SKILL.md`, and the homepage Tools card in sync

## Baseline

Tested with Opus 4.8 high and GPT-5.5 Pro on a realistic Ethereum debugging prompt covering:

- `Panic(uint256)` code `0x11`
- `AA23 reverted or OOG`
- HTTP `402` / `insufficient_funds` on `eip155:8453`
- selector `0x08c379a0`

Both models correctly decoded the common cases. So this PR does **not** try to teach basic revert decoding.

The gap: both models defaulted to hand-rolled app-side decoder tables and troubleshooting prose. Neither mentioned an existing searchable catalog, hosted HTTP API, MCP server, or client SDK.

## Triage

- 🟢 Common decode facts (`Panic(0x11)`, `AA23`, `Error(string)`, Base chain id): cut
- 🔴 Current searchable catalog/API/MCP/client path: keep
- 🔴 “Use the maintained catalog before hand-rolling decoder tables”: keep
- 🟡 Bounded search / focused lookup / avoid dumping a full catalog into context or browser bundles: compressed into one agent-pattern paragraph

## Placement

This belongs in `tools/SKILL.md`, not a new skill, because the baseline shows the missing piece is tool discovery. The models already know the common decoding concepts; they skip the maintained tool path.

## Verification

- `POST https://revert.wtf/api/search` returns bounded catalog results
- `POST https://revert.wtf/api/explain` returns normalized explanations with evidence and next steps
- `POST /api/revert-decode`, `/api/aa-decode`, and `/api/selector` return focused decoder results
- `@revertwtf/mcp` is published on npm
- `git diff --check`