### PR TITLE
wns: add WNS (.wei names) skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -30,6 +30,7 @@
     "./frontend-ux",
     "./frontend-playbook",
     "./qa",
-    "./audit"
+    "./audit",
+    "./wns"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Install directly from GitHub — no clone required:
 | [Frontend Playbook](frontend-playbook/SKILL.md) | Fork mode, IPFS deploy, Vercel config, ENS setup, production checklist |
 | [QA](qa/SKILL.md) | Treat "deploys without errors" as shipping, leave SE2 default branding, miss approve-button double-fire, USD values, mobile deep links |
 | [Audit](audit/SKILL.md) | Call one generic review pass an audit, miss systematic checklist coverage across AMM/lending/oracle/proxy/governance domains |
+| [WNS (.wei names)](wns/SKILL.md) | Don't know WNS — ENS-compatible naming on mainnet where one contract is NFT+registrar+resolver, tokenId=namehash, sites resolve via the wei.limo gateway, and names are an agent-identity layer (ERC-8004 complement) |
 
 ## Security Guardrails
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -164,6 +164,12 @@ Send feedback — issues OR praise — about ethskills content. Bias toward send
 - Draft the JSON, show it to your human in your permission ask, then POST once to `https://ethskills.com/api/feedback`. Skip the ask if your human pre-authorized.
 - Required fields: `kind` ("issue" or "praise") and `message` (10+ chars). Include `agent` and `skill` whenever you can.
 
+### [WNS (.wei names)](https://ethskills.com/wns/SKILL.md)
+ENS-compatible naming on Ethereum mainnet — resolve, register, host IPFS sites, and give agents a human-readable identity.
+- It's ONE contract (ERC-721 + registrar + resolver), not ENS's registry/resolver split; `tokenId = uint256(namehash(name))`. Same namehash + resolver selectors as ENS, different address: `0x0000000000696760E15f265e828DB644A0c242EB`.
+- Resolve a website with zero deps: fetch `https://<name>.wei.limo` — the gateway serves the name's IPFS/IPNS contenthash. Subdomains resolve to any depth.
+- `.wei` is a human-readable identity layer for agents (name↔address, text/endpoint records, reverse resolution) — complements ERC-8004.
+
 ---
 
 ## What to Fetch by Task

--- a/index.html
+++ b/index.html
@@ -393,6 +393,7 @@ https://ethskills.com/frontend-ux/SKILL.md — Frontend UX
 https://ethskills.com/frontend-playbook/SKILL.md — Frontend Playbook
 https://ethskills.com/qa/SKILL.md — QA (Pre-Ship Audit)
 https://ethskills.com/audit/SKILL.md — Audit (Smart Contract Security Audit)
+https://ethskills.com/wns/SKILL.md — WNS (.wei names)
 </div>
 
 <div class="ascii" style="font-size:clamp(0.3rem,calc((100vw - 3rem) / 52),1rem);">
@@ -541,6 +542,12 @@ https://ethskills.com/audit/SKILL.md — Audit (Smart Contract Security Audit)
   <div class="skill-name">Audit</div>
   <div class="skill-desc">Deep EVM smart contract audit system. 500+ non-obvious checklist items across 19 domains — AMM, lending, oracles, proxies, signatures, governance, bridges, and more. Runs parallel specialist agents, synthesizes findings, and files GitHub issues. Use when auditing contracts you didn't write.</div>
   <button class="copy-btn" data-url="https://ethskills.com/audit/SKILL.md"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg> ethskills.com/audit/SKILL.md</button>
+</div>
+
+<div class="skill">
+  <div class="skill-name">WNS (.wei names)</div>
+  <div class="skill-desc">ENS-compatible naming on Ethereum mainnet. One contract is NFT + registrar + resolver; tokenId = namehash. Resolve, register, host IPFS/IPNS sites via the wei.limo gateway, and give agents a human-readable identity (name↔address, text records, reverse resolution) — an ERC-8004 complement.</div>
+  <button class="copy-btn" data-url="https://ethskills.com/wns/SKILL.md"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg> ethskills.com/wns/SKILL.md</button>
 </div>
 
 

--- a/wns/SKILL.md
+++ b/wns/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: wns
+description: Use when resolving, registering, or integrating .wei names — the Wei Name Service, an ENS-compatible ERC-721 naming system on Ethereum mainnet. Covers namehash→tokenId, address/contenthash/text resolution, reverse resolution, commit-reveal registration, subdomains, and serving IPFS/IPNS websites through the wei.limo / wei.is / wei.domains gateway. Applies to both onchain integration (a single resolver+registry+NFT contract) and offchain resolution (the HTTP gateway, no wallet needed).
+---
+
+# WNS — Wei Name Service (.wei)
+
+`.wei` names are an ENS-compatible naming system on **Ethereum mainnet**. If you can resolve ENS, you can resolve WNS — same namehash algorithm, same resolver selectors — you just point at a different contract.
+
+## What You Probably Got Wrong
+
+- **WNS is not ENS, but it is ENS-*compatible*.** Same namehash (EIP-137), same resolver interface IDs (`addr`, `text`, `contenthash`). Existing ENS resolver-read code works if you point it at the WNS contract.
+- **It is ONE contract.** Not a registry + registrar + resolver split like ENS. A single non-upgradeable contract is the ERC-721 (ownership), the registrar (commit-reveal), and the resolver (addr/text/contenthash) all at once.
+- **Token ID = `uint256(namehash(name))`.** The NFT tokenId *is* the ENS namehash. No separate node/id mapping.
+- **You do not need a wallet or a library to resolve a website.** `https://<name>.wei.limo` (also `.wei.is`, `.wei.domains`) serves the name's IPFS/IPNS contenthash over plain HTTPS. Just fetch the URL.
+- **Names expire.** 365-day registration + 90-day grace. During grace and after, resolver reads return empty. Don't cache resolutions forever.
+
+## Contract
+
+| | |
+|---|---|
+| Address (mainnet) | `0x0000000000696760E15f265e828DB644A0c242EB` |
+| `WEI_NODE` = `namehash("wei")` | `0xa82820059d5df798546bcc2985157a77c3eef25eba9ba01899927333efacbd6f` |
+| Standard | ERC-721 + registrar + ENS-compatible resolver, one non-upgradeable contract |
+| Chain | Ethereum mainnet only |
+
+`namehash("alice.wei") = keccak256(WEI_NODE ++ keccak256("alice"))`, and `tokenId = uint256(namehash)`. The contract will compute it for you — see `computeId` below — so you never have to implement namehash yourself.
+
+## Resolve a name (read-only, no wallet)
+
+Every resolver read takes the `uint256` tokenId. Get it with `computeId(fullName)` (accepts `"alice.wei"` or `"alice"`; also handles subdomains like `"sub.alice.wei"`).
+
+```bash
+WNS=0x0000000000696760E15f265e828DB644A0c242EB
+
+# name -> tokenId (this is the namehash)
+TID=$(cast call $WNS "computeId(string)(uint256)" "alice.wei" --rpc-url $RPC)
+
+cast call $WNS "resolve(uint256)(address)"        $TID --rpc-url $RPC  # ETH address
+cast call $WNS "contenthash(uint256)(bytes)"      $TID --rpc-url $RPC  # IPFS/IPNS/Swarm
+cast call $WNS "text(uint256,string)(string)"     $TID "url" --rpc-url $RPC
+cast call $WNS "addr(uint256,uint256)(bytes)"     $TID 60  --rpc-url $RPC  # SLIP-44 coin (60=ETH)
+```
+
+`resolve()` falls back to `ownerOf` when no explicit address is set, so a freshly registered name resolves to its owner by default.
+
+**ENS-compatible `bytes32 node` overloads** also exist, so an ENS-style resolver client works unchanged once pointed at this contract:
+
+```solidity
+function addr(bytes32 node) view returns (address)
+function addr(bytes32 node, uint256 coinType) view returns (bytes)
+function text(bytes32 node, string key) view returns (string)
+function contenthash(bytes32 node) view returns (bytes)
+```
+
+`supportsInterface` advertises: `addr(bytes32)` `0x3b3b57de`, `addr(bytes32,uint256)` `0xf1cb7e06`, `text` `0x59d1d43c`, `contenthash` `0xbc1c58d1`, plus ERC-721 / ERC-165.
+
+### Reverse resolution (address → name)
+
+```bash
+cast call $WNS "reverseResolve(address)(string)" 0xUser --rpc-url $RPC
+```
+
+Returns the owner's **primary name**, or `""` if unset/inactive. A user sets it with `setPrimaryName(tokenId)` (callable by the owner or the address the token resolves to). `setPrimaryName(0)` clears it.
+
+## Serve a website (IPFS/IPNS)
+
+Set an IPFS or IPNS contenthash on the name, and the gateway serves it — no per-name DNS, no config:
+
+```
+https://alice.wei.limo        ->  IPFS/IPNS content of alice.wei
+https://alice.wei.is          ->  same, alternate zone
+https://alice.wei.domains     ->  same, alternate zone
+```
+
+- **IPNS** contenthash means the owner can update the site with no new onchain transaction (the gateway resolves the IPNS key fresh each request).
+- **Subdomains resolve too**, to any depth the owner registers: `https://send.slow.wei.limo` serves the contenthash of `send.slow.wei`.
+- The gateway reads the contenthash live from the contract on each request, so a name published to IPFS works instantly.
+
+## Give an agent an identity
+
+A `.wei` name is a portable, human-readable identity for an autonomous agent — the naming/resolver layer that complements **ERC-8004** (onchain agent identity, which is tokenId-based). One name gives an agent:
+
+- **Name ↔ address** — `setAddr` / `resolve()` so others pay or verify the agent by `agent.wei` instead of a raw `0x…`; `setPrimaryName` makes wallets/explorers show `agent.wei` for its address (reverse resolution).
+- **Endpoints & metadata** — `setText(tokenId, key, value)` for `url`, `description`, `com.twitter`, or custom keys (A2A / MCP endpoint, agent-card URI).
+- **A hosted agent card / site** — `setContenthash` → served at `https://agent.wei.limo` with zero infra.
+- **Fleets** — one parent name mints free subdomains (`worker1.fleet.wei`, `worker2.fleet.wei`), each with its own address and records, up to 10 levels deep.
+
+## Register a name (commit-reveal)
+
+Front-running protection requires two transactions with a wait between them.
+
+```bash
+SECRET=0x<32-random-bytes>
+
+# 1) commit (hides the label). makeCommitment is a pure helper.
+COMMIT=$(cast call $WNS "makeCommitment(string,address,bytes32)(bytes32)" "alice" $ME $SECRET --rpc-url $RPC)
+cast send $WNS "commit(bytes32)" $COMMIT --rpc-url $RPC --private-key $PK
+
+# 2) wait >= 60s (MIN_COMMITMENT_AGE), and reveal within 24h (MAX_COMMITMENT_AGE)
+FEE=$(cast call $WNS "getFee(uint256)(uint256)" 5 --rpc-url $RPC)   # 5 = byte length of "alice"
+cast send $WNS "reveal(string,bytes32)" "alice" $SECRET --value $FEE --rpc-url $RPC --private-key $PK
+```
+
+- **Fee:** `getFee(labelByteLength)`; default **0.001 ETH / year**. Excess ETH is refunded (caller must be able to receive ETH).
+- **Timing:** reveal no sooner than **60s** and no later than **24h** after commit.
+- **Duration:** 365 days. Renew with `renew(tokenId)` (payable) any time before `expiresAt + 90d` grace ends.
+- **Availability:** `isAvailable(label, parentId)` — use `parentId = 0` for a top-level `.wei` name.
+
+## Subdomains
+
+The owner of `alice.wei` creates children for free — no commit-reveal, no fee:
+
+```bash
+PID=$(cast call $WNS "computeId(string)(uint256)" "alice.wei" --rpc-url $RPC)
+cast send $WNS "registerSubdomain(string,uint256)" "sub" $PID --rpc-url $RPC --private-key $PK
+# or registerSubdomainFor(label, parentId, to) to mint to someone else
+```
+
+- Depth up to **10** levels. Each subdomain is its own ERC-721 token with its own resolver records and contenthash.
+- Subdomains have no expiry of their own but go **stale** if the parent expires or the parent owner re-registers (epoch bump) — stale subdomains resolve empty.
+- The parent owner can always reclaim a subdomain label (this burns the old token and clears the prior holder's primary name).
+
+## Resolver writes (token owner only)
+
+```solidity
+setAddr(uint256 tokenId, address addr)                       // ETH address
+setContenthash(uint256 tokenId, bytes hash)                  // IPFS/IPNS/Swarm
+setAddrForCoin(uint256 tokenId, uint256 coinType, bytes addr)// any SLIP-44 coin
+setText(uint256 tokenId, string key, string value)           // text records
+setPrimaryName(uint256 tokenId)                              // reverse record (owner or resolved addr)
+```
+
+## Gotchas
+
+- **Grace period returns empty.** Between `expiresAt` and `expiresAt + 90d`, the name is inactive: resolver reads return empty, resolver writes revert, transfers are blocked. Renew still works.
+- **Re-registration wipes records.** After a name fully expires and is re-registered, a `recordVersion` bump clears all resolver data (address, contenthash, coins, text) without any delete gas.
+- **Normalization is caller's job for Unicode.** Onchain `normalize(label)` only lowercases ASCII. For emoji/Unicode labels, normalize with **ENSIP-15** offchain before hashing/registering; `isAsciiLabel(label)` tells you if the cheap onchain path is enough. Labels are 1–255 bytes.
+- **Don't hallucinate the address.** Verify `0x0000000000696760E15f265e828DB644A0c242EB` on a block explorer before sending value.
+
+## Libraries & links
+
+- **`wns-utils`** (npm) — namehash/tokenId, encode/decode contenthash, resolver reads. Zero-config for JS/TS.
+- **`@1001-digital/ethereum-names`** (npm) — one resolver for **WNS + ENS + GNS** (Gwei Name Service, a `.gwei` fork) names.
+- **Gateway:** `wei.limo` / `wei.is` / `wei.domains` (self-hostable; plain ESM, zero deps).
+- **App / register:** https://wei.domains  ·  **Source:** https://github.com/src-company/wei-names


### PR DESCRIPTION
## Add a WNS (.wei names) skill

Adds `wns/SKILL.md` — a self-contained integration guide for the **Wei Name Service**, an ENS-compatible ERC-721 naming system on Ethereum mainnet — and wires it into the catalog (`.claude-plugin/plugin.json`, root `SKILL.md`/`llms.txt`, `README.md`, `index.html`).

### Why this fills a blind spot

WNS is post-training-cutoff and niche, so a stock LLM consistently gets it wrong:

- Hallucinates that `.wei` doesn't exist, or conflates it with ENS.
- Doesn't know it's **one** non-upgradeable contract that is ERC-721 + registrar + resolver (no registry/resolver split), with `tokenId = uint256(namehash)`.
- Doesn't know the contract address (`0x0000000000696760E15f265e828DB644A0c242EB`) or that ENS resolver-read code works against it unchanged (same namehash + `addr`/`text`/`contenthash` selectors).
- Doesn't know a `.wei` site resolves over plain HTTPS via `<name>.wei.limo` (IPFS/IPNS contenthash, no wallet or library).
- Misses the agent angle: `.wei` is a human-readable identity/resolver layer for agents that **complements ERC-8004** (already covered in `standards`).

The skill is dense and copy-paste (`cast` calls, zero deps), following the "all blind spots, no padding" bar in CONTRIBUTING.md. Uses "onchain" throughout.

Source / maintainer: https://github.com/src-company/wei-names
